### PR TITLE
Support for deSEC (desec.io)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 _ignore
 Cargo.lock
+
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ dns-update 0.2.0
 ================================
 - Add desec.io provider.
 - Add retry function to http client
-- Moved `strip_origin_from_name` form `cloudflare` to `lib`
+- Moved `strip_origin_from_name` form `digitalocean` to `lib`
 - Fixed cargo test 
 
 dns-update 0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+dns-update 0.2.0
+================================
+- Add desec.io provider.
+
 dns-update 0.1.3
 ================================
 - Add Gandi provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 dns-update 0.2.0
 ================================
 - Add desec.io provider.
+- Add retry function to http client
+- Moved `strip_origin_from_name` form `cloudflare` to `lib`
+- Fixed cargo test 
 
 dns-update 0.1.3
 ================================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dns-update"
 description = "Dynamic DNS update (RFC 2136 and cloud) library for Rust"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = [ "Stalwart Labs <hello@stalw.art>"]
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "http2"]}
 serde_urlencoded = "0.7.1"
-strum_macros = "0.27.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 mockito = "1.2"
-base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "http2"]}
 serde_urlencoded = "0.7.1"
+strum_macros = "0.27.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,5 @@ strum_macros = "0.27.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+mockito = "1.2"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PRs to add more providers are welcome. The goal is to support as many providers 
 
 Using RFC2136 with TSIG:
 
-```rust
+```rust,ignore
         // Create a new RFC2136 client
         let client = Rfc2136Provider::new_tsig("tcp://127.0.0.1:53", "<KEY_NAME>", STANDARD.decode("<TSIG_KEY>").unwrap(), TsigAlgorithm::HmacSha512).unwrap();
 
@@ -44,7 +44,7 @@ Using RFC2136 with TSIG:
 
 Using a cloud provider such as Cloudflare:
 
-```rust
+```rust,ignore
         // Create a new Cloudflare client
         let client =
             DnsUpdater::new_cloudflare("<API_TOKEN>", None::<String>, Some(Duration::from_secs(60)))

--- a/src/http.rs
+++ b/src/http.rs
@@ -144,6 +144,9 @@ impl HttpClient {
             .map_err(|err| Error::Api(format!("Failed to send request to {}: {err}", self.url)))?;
 
         match response.status().as_u16() {
+            204 => serde_json::from_str("{}").map_err(|err| {
+                Error::Serialize(format!("Failed to create empty response: {err}"))
+            }),
             200..=299 => response.text().await.map_err(|err| {
                 Error::Api(format!("Failed to read response from {}: {err}", self.url))
             }),
@@ -181,6 +184,9 @@ impl HttpClient {
                 .map_err(|err| Error::Api(format!("Failed to send request to {}: {err}", self.url)))?;
 
             return match response.status().as_u16() {
+                204 => serde_json::from_str("{}").map_err(|err| {
+                    Error::Serialize(format!("Failed to create empty response: {err}"))
+                }),
                 200..=299 => {
                     let text = response.text().await.map_err(|err| {
                         Error::Api(format!("Failed to read response from {}: {err}", self.url))

--- a/src/http.rs
+++ b/src/http.rs
@@ -147,6 +147,7 @@ impl HttpClient {
             200..=299 => response.text().await.map_err(|err| {
                 Error::Api(format!("Failed to read response from {}: {err}", self.url))
             }),
+            400 => Err(Error::BadRequest),
             401 => Err(Error::Unauthorized),
             404 => Err(Error::NotFound),
             code => Err(Error::Api(format!(

--- a/src/http.rs
+++ b/src/http.rs
@@ -156,4 +156,57 @@ impl HttpClient {
             ))),
         }
     }
+
+    pub async fn send_with_retry<T>(self, max_retries: u32) -> crate::Result<T>
+    where 
+        T: DeserializeOwned,
+    {
+        let mut attempts = 0;
+        let body = self.body;
+        loop {
+            let mut request = reqwest::Client::builder()
+                .timeout(self.timeout)
+                .build()
+                .unwrap_or_default()
+                .request(self.method.clone(), &self.url)
+                .headers(self.headers.clone());
+
+            if let Some(body) = body.as_ref() {
+                request = request.body(body.clone());
+            }
+
+            let response = request
+                .send()
+                .await
+                .map_err(|err| Error::Api(format!("Failed to send request to {}: {err}", self.url)))?;
+
+            return match response.status().as_u16() {
+                200..=299 => {
+                    let text = response.text().await.map_err(|err| {
+                        Error::Api(format!("Failed to read response from {}: {err}", self.url))
+                    })?;
+                    serde_json::from_str(&text).map_err(|err| {
+                        Error::Serialize(format!("Failed to deserialize response: {err}"))
+                    })
+                }
+                429 if attempts < max_retries => {
+                    if let Some(retry_after) = response.headers().get("retry-after") {
+                        if let Ok(seconds) = retry_after.to_str().unwrap_or("0").parse::<u64>() {
+                            tokio::time::sleep(Duration::from_secs(seconds)).await;
+                            attempts += 1;
+                            continue;
+                        }
+                    }
+                    Err(Error::Api("Rate limit exceeded".to_string()))
+                }
+                400 => Err(Error::BadRequest),
+                401 => Err(Error::Unauthorized),
+                404 => Err(Error::NotFound),
+                code => Err(Error::Api(format!(
+                    "Invalid HTTP response code {code}: {:?}",
+                    response.error_for_status()
+                ))),
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ use std::{
 };
 
 use hickory_client::proto::rr::dnssec::{KeyPair, Private};
-use strum_macros::Display;
 
 use providers::{
     cloudflare::CloudflareProvider,
@@ -46,8 +45,7 @@ pub enum Error {
 }
 
 /// A DNS record type.
-#[derive(Display)]
-#[strum(serialize_all = "UPPERCASE")]
+#[derive(Debug)]
 pub enum DnsRecordType {
     A,
     AAAA,
@@ -59,8 +57,6 @@ pub enum DnsRecordType {
 }
 
 /// A DNS record type with a value.
-#[derive(Display)]
-#[strum(serialize_all = "UPPERCASE")]
 pub enum DnsRecord {
     A {
         content: Ipv4Addr,
@@ -332,5 +328,11 @@ impl Display for Error {
             Error::NotFound => write!(f, "Not found"),
             Error::BadRequest => write!(f, "Bad request"),
         }
+    }
+}
+
+impl Display for DnsRecordType {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,11 +186,10 @@ impl DnsUpdater {
     /// Create a new DNS updater using the Desec.io API.
     pub fn new_desec(
         auth_token: impl AsRef<str>,
-        endpoint: Option<impl AsRef<str>>,
         timeout: Option<Duration>,
     ) -> crate::Result<Self> {
         Ok(DnsUpdater::Desec(DesecProvider::new(
-            auth_token, endpoint, timeout,
+            auth_token, timeout
         )))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@ use strum_macros::Display;
 
 use providers::{
     cloudflare::CloudflareProvider,
+    desec::DesecProvider,
     digitalocean::DigitalOceanProvider,
     rfc2136::{DnsAddress, Rfc2136Provider},
 };
-use crate::providers::desec::DesecProvider;
 
 pub mod http;
 pub mod providers;
@@ -42,7 +42,7 @@ pub enum Error {
     Serialize(String),
     Unauthorized,
     NotFound,
-    BadRequest
+    BadRequest,
 }
 
 /// A DNS record type.
@@ -57,7 +57,6 @@ pub enum DnsRecordType {
     TXT,
     SRV,
 }
-
 
 /// A DNS record type with a value.
 #[derive(Display)]
@@ -188,9 +187,7 @@ impl DnsUpdater {
         auth_token: impl AsRef<str>,
         timeout: Option<Duration>,
     ) -> crate::Result<Self> {
-        Ok(DnsUpdater::Desec(DesecProvider::new(
-            auth_token, timeout
-        )))
+        Ok(DnsUpdater::Desec(DesecProvider::new(auth_token, timeout)))
     }
 
     /// Create a new DNS record.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,10 +171,11 @@ impl DnsUpdater {
     /// Create a new DNS updater using the Desec.io API.
     pub fn new_desec(
         auth_token: impl AsRef<str>,
+        endpoint: Option<impl AsRef<str>>,
         timeout: Option<Duration>,
     ) -> crate::Result<Self> {
         Ok(DnsUpdater::Desec(DesecProvider::new(
-            auth_token, timeout,
+            auth_token, endpoint, timeout,
         )))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use providers::{
     digitalocean::DigitalOceanProvider,
     rfc2136::{DnsAddress, Rfc2136Provider},
 };
+use crate::providers::desec::DesecProvider;
 
 pub mod http;
 pub mod providers;
@@ -100,6 +101,7 @@ pub enum DnsUpdater {
     Rfc2136(Rfc2136Provider),
     Cloudflare(CloudflareProvider),
     DigitalOcean(DigitalOceanProvider),
+    Desec(DesecProvider),
 }
 
 pub trait IntoFqdn<'x> {
@@ -161,6 +163,16 @@ impl DnsUpdater {
         )))
     }
 
+    /// Create a new DNS updater using the Desec.io API.
+    pub fn new_desec(
+        auth_token: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> crate::Result<Self> {
+        Ok(DnsUpdater::Desec(DesecProvider::new(
+            auth_token, timeout,
+        )))
+    }
+
     /// Create a new DNS record.
     pub async fn create(
         &self,
@@ -173,6 +185,7 @@ impl DnsUpdater {
             DnsUpdater::Rfc2136(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Cloudflare(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::DigitalOcean(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Desec(provider) => provider.create(name, record, ttl, origin).await,
         }
     }
 
@@ -188,6 +201,7 @@ impl DnsUpdater {
             DnsUpdater::Rfc2136(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Cloudflare(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::DigitalOcean(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Desec(provider) => provider.update(name, record, ttl, origin).await,       
         }
     }
 
@@ -201,6 +215,7 @@ impl DnsUpdater {
             DnsUpdater::Rfc2136(provider) => provider.delete(name, origin).await,
             DnsUpdater::Cloudflare(provider) => provider.delete(name, origin).await,
             DnsUpdater::DigitalOcean(provider) => provider.delete(name, origin).await,
+            DnsUpdater::Desec(provider) => provider.delete(name, origin).await,       
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,20 @@ pub enum Error {
 /// A DNS record type.
 #[derive(Display)]
 #[strum(serialize_all = "UPPERCASE")]
+pub enum DnsRecordType {
+    A,
+    AAAA,
+    CNAME,
+    NS,
+    MX,
+    TXT,
+    SRV,
+}
+
+
+/// A DNS record type with a value.
+#[derive(Display)]
+#[strum(serialize_all = "UPPERCASE")]
 pub enum DnsRecord {
     A {
         content: Ipv4Addr,
@@ -217,7 +231,7 @@ impl DnsUpdater {
         &self,
         name: impl IntoFqdn<'_>,
         origin: impl IntoFqdn<'_>,
-        record: DnsRecord,
+        record: DnsRecordType,
     ) -> crate::Result<()> {
         match self {
             DnsUpdater::Rfc2136(provider) => provider.delete(name, origin).await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use crate::providers::desec::DesecProvider;
 
 pub mod http;
 pub mod providers;
+pub mod tests;
 
 #[derive(Debug)]
 pub enum Error {
@@ -270,6 +271,21 @@ impl<'x> IntoFqdn<'x> for String {
         } else {
             Cow::Owned(self)
         }
+    }
+}
+
+pub fn strip_origin_from_name(name: &str, origin: &str) -> String {
+    let name = name.trim_end_matches('.');
+    let origin = origin.trim_end_matches('.');
+
+    if name == origin {
+        return "@".to_string();
+    }
+
+    if name.ends_with(&format!(".{}", origin)) {
+        name[..name.len() - origin.len() - 1].to_string()
+    } else {
+        name.to_string()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub enum Error {
     Serialize(String),
     Unauthorized,
     NotFound,
+    BadRequest
 }
 
 /// A DNS record type.
@@ -302,6 +303,7 @@ impl Display for Error {
             Error::Serialize(e) => write!(f, "Serialize error: {}", e),
             Error::Unauthorized => write!(f, "Unauthorized"),
             Error::NotFound => write!(f, "Not found"),
+            Error::BadRequest => write!(f, "Bad request"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ use std::{
 };
 
 use hickory_client::proto::rr::dnssec::{KeyPair, Private};
+use strum_macros::Display;
+
 use providers::{
     cloudflare::CloudflareProvider,
     digitalocean::DigitalOceanProvider,
@@ -42,6 +44,8 @@ pub enum Error {
 }
 
 /// A DNS record type.
+#[derive(Display)]
+#[strum(serialize_all = "UPPERCASE")]
 pub enum DnsRecord {
     A {
         content: Ipv4Addr,
@@ -201,7 +205,7 @@ impl DnsUpdater {
             DnsUpdater::Rfc2136(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Cloudflare(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::DigitalOcean(provider) => provider.update(name, record, ttl, origin).await,
-            DnsUpdater::Desec(provider) => provider.update(name, record, ttl, origin).await,       
+            DnsUpdater::Desec(provider) => provider.update(name, record, ttl, origin).await,
         }
     }
 
@@ -210,12 +214,13 @@ impl DnsUpdater {
         &self,
         name: impl IntoFqdn<'_>,
         origin: impl IntoFqdn<'_>,
+        record: DnsRecord,
     ) -> crate::Result<()> {
         match self {
             DnsUpdater::Rfc2136(provider) => provider.delete(name, origin).await,
             DnsUpdater::Cloudflare(provider) => provider.delete(name, origin).await,
             DnsUpdater::DigitalOcean(provider) => provider.delete(name, origin).await,
-            DnsUpdater::Desec(provider) => provider.delete(name, origin).await,       
+            DnsUpdater::Desec(provider) => provider.delete(name, origin, record).await,
         }
     }
 }

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -55,20 +55,27 @@ pub struct DesecApiResponse {
 #[derive(Deserialize)]
 struct DesecEmptyResponse {}
 
-
+/// The default endpoint for the desec API.
 const DEFAULT_API_ENDPOINT: &str = "https://desec.io/api/v1";
 
 impl DesecProvider {
-    pub(crate) fn new(auth_token: impl AsRef<str>, endpoint: Option<impl AsRef<str>>, timeout: Option<Duration>) -> Self {
+    pub(crate) fn new(auth_token: impl AsRef<str>, timeout: Option<Duration>) -> Self {
         let client = HttpClientBuilder::default()
             .with_header("Authorization", format!("Token {}", auth_token.as_ref()))
             .with_timeout(timeout);
+        
+        Self { 
+            client, 
+            endpoint: DEFAULT_API_ENDPOINT.to_string() 
+        }
+    }
 
-        let endpoint = endpoint
-            .map(|e| e.as_ref().to_string())
-            .unwrap_or_else(|| DEFAULT_API_ENDPOINT.to_string());
-
-        Self { client, endpoint }
+    #[cfg(test)]
+    pub(crate) fn with_endpoint(self, endpoint: impl AsRef<str>) -> Self {
+        Self {
+            endpoint: endpoint.as_ref().to_string(),
+            ..self
+        }
     }
     
     pub(crate) async fn create(

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -1,0 +1,237 @@
+/*
+ * Copyright Stalwart Labs Ltd. See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    time::Duration,
+};
+use hickory_client::rr::{Name, RData, RecordType};
+use hickory_client::rr::rdata::{A, AAAA, CNAME, MX, NS, SRV, TXT};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{http::HttpClientBuilder, DnsRecord, Error, IntoFqdn};
+
+#[derive(Clone)]
+pub struct DesecProvider {
+    client: HttpClientBuilder,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct IdMap {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Debug)]
+pub struct Query {
+    name: String,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct CreateDnsRecordParams<'a> {
+    pub subname: &'a str,
+    pub r#type: &'a str,
+    pub ttl: Option<u32>,
+    #[serde(flatten)]
+    pub records: Vec<String>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct UpdateDnsRecordParams<'a> {
+    pub subname: &'a str,
+    pub r#type: &'a str,
+    pub ttl: Option<u32>,
+    #[serde(flatten)]
+    pub records: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct ApiResult<T> {
+    errors: Vec<ApiError>,
+    success: bool,
+    result: T,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ApiError {
+    pub code: u16,
+    pub message: String,
+}
+
+const DEFAULT_API_ENDPOINT: &str = "https://desec.io/api/v1/";
+
+impl DesecProvider {
+    pub(crate) fn new(auth_token: impl AsRef<str>, timeout: Option<Duration>) -> Self {
+        let client = HttpClientBuilder::default()
+            .with_header("Authorization", format!("Token {}", auth_token.as_ref()))
+            .with_timeout(timeout);
+        Self { client }
+    }
+
+    async fn check_ownership(&self, origin: impl IntoFqdn<'_>) -> crate::Result<String> {
+        let origin = origin.into_name();
+        self.client
+            .get(format!(
+                "{endpoint}/domains/?owns_qname={qname}",
+                endpoint = DEFAULT_API_ENDPOINT,
+                qname = Query::name(origin.as_ref()).serialize()
+            ))
+            .send::<ApiResult<Vec<IdMap>>>()
+            .await
+            .and_then(|r| r.unwrap_response("list zones"))
+            .and_then(|result| {
+                result
+                    .into_iter()
+                    .find(|zone| zone.name == origin.as_ref())
+                    .map(|zone| zone.id)
+                    .ok_or_else(|| Error::Api(format!("Zone {} not found", origin.as_ref())))
+            })
+    }
+
+
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let (rr_type, rr_content) = convert_record(record)?;
+        self.client
+            .post(format!(
+                "{endpoint}/domains/{name}/rrsets/{subname}/{rtype}",
+                endpoint = DEFAULT_API_ENDPOINT,
+                name = origin.into_name().as_ref(),
+                subname = &name,
+                rtype = rr_type,
+            ))
+            .with_body(CreateDnsRecordParams {
+                subname: &name,
+                r#type: &rr_type,
+                ttl: Some(ttl),
+                records: vec![rr_content.into()],
+            })?
+            .send::<ApiResult<Value>>()
+            .await
+            .map(|_| ())
+    }
+
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let (rr_type, rr_content) = convert_record(record)?;
+        self.client
+            .patch(format!(
+                "{endpoint}/domains/{name}/rrsets/{subname}/{rtype}",
+                endpoint = DEFAULT_API_ENDPOINT,
+                name = origin.into_name().as_ref(),
+                subname = &name,
+                rtype = rr_type,
+            ))
+            .with_body(UpdateDnsRecordParams {
+                subname: &name,
+                r#type: &rr_type,
+                ttl: Some(ttl),
+                records: vec![rr_content.into()],
+            })?
+            .send::<ApiResult<Value>>()
+            .await
+            .map(|_| ())
+    }
+
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        
+        self.client
+            .delete(format!(
+                "{endpoint}/domains/{name}/rrsets/{subname}/{rtype}",
+                endpoint = DEFAULT_API_ENDPOINT,
+                name = origin.into_name().as_ref(),
+                subname = &name,
+                rtype = rr_type,
+            ))
+            .send::<ApiResult<Value>>()
+            .await
+            .map(|_| ())
+    }
+}
+
+impl<T> ApiResult<T> {
+    fn unwrap_response(self, action_name: &str) -> crate::Result<T> {
+        if self.success {
+            Ok(self.result)
+        } else {
+            Err(Error::Api(format!(
+                "Failed to {action_name}: {:?}",
+                self.errors
+            )))
+        }
+    }
+}
+
+impl Query {
+    pub fn name(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    pub fn serialize(&self) -> String {
+        serde_urlencoded::to_string(self).unwrap()
+    }
+}
+
+fn convert_record(record: DnsRecord) -> crate::Result<(String, String)> {
+    Ok(match record {
+        DnsRecord::A { content } => (
+            "A".to_string(),
+            content.to_string()
+        ),
+        DnsRecord::AAAA { content } => (
+            "AAAA".to_string(),
+            content.to_string()
+        ),
+        DnsRecord::CNAME { content } => (
+            "CNAME".to_string(),
+            content
+        ),
+        DnsRecord::NS { content } => (
+            "NS".to_string(),
+            content
+        ),
+        DnsRecord::MX { content, priority } => (
+            "MX".to_string(),
+            format!("{priority} {name}",
+                priority = priority,
+                name = content)
+        ),
+        DnsRecord::TXT { content } => (
+            "TXT".to_string(),
+            content
+        ),
+        DnsRecord::SRV { content, priority, weight, port } => (
+            "SRV".to_string(),
+            format!("{priority} {weight} {port} {name}",
+                priority = priority,
+                weight = weight,
+                port = port,
+                name = content)
+        ),
+    })
+}

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -90,7 +90,7 @@ impl DesecProvider {
                 ttl: Some(ttl),
                 records: vec![rr_content.into()],
             })?
-            .send::<ApiResult<Value>>()
+            .send_with_retry::<ApiResult<Value>>(3)
             .await
             .map(|_| ())
     }
@@ -119,7 +119,7 @@ impl DesecProvider {
                 ttl: Some(ttl),
                 records: vec![rr_content.into()],
             })?
-            .send::<ApiResult<Value>>()
+            .send_with_retry::<ApiResult<Value>>(3)
             .await
             .map(|_| ())
     }
@@ -140,7 +140,7 @@ impl DesecProvider {
                 subname = name.as_ref(),
                 rtype = &rr_type,
             ))
-            .send::<ApiResult<Value>>()
+            .send_with_retry::<ApiResult<Value>>(3)
             .await
             .map(|_| ())
     }

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -92,11 +92,9 @@ impl DesecProvider {
         let desec_record = DesecDnsRecordRepresentation::from(record);
         self.client
             .post(format!(
-                "{endpoint}/domains/{domain}/rrsets/{subdomain}/{rr_type}/",
+                "{endpoint}/domains/{domain}/rrsets/",
                 endpoint = self.endpoint,
-                domain = domain,
-                subdomain = &subdomain,
-                rr_type = &desec_record.record_type,
+                domain = domain
             ))
             .with_body(DnsRecordParams {
                 subname: &subdomain,
@@ -130,7 +128,7 @@ impl DesecProvider {
                 rr_type = &desec_record.record_type,
             ))
             .with_body(DnsRecordParams {
-                subname: &name,
+                subname: &subdomain,
                 rr_type: desec_record.record_type.as_str(),
                 ttl: Some(ttl),
                 records: vec![desec_record.content],

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -9,13 +9,11 @@
  * except according to those terms.
  */
 
-use std::{
-    time::Duration,
-};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{http::HttpClientBuilder, DnsRecord, IntoFqdn, strip_origin_from_name, DnsRecordType};
+use crate::{http::HttpClientBuilder, strip_origin_from_name, DnsRecord, DnsRecordType, IntoFqdn};
 
 pub struct DesecDnsRecordRepresentation {
     pub record_type: String,
@@ -63,10 +61,10 @@ impl DesecProvider {
         let client = HttpClientBuilder::default()
             .with_header("Authorization", format!("Token {}", auth_token.as_ref()))
             .with_timeout(timeout);
-        
-        Self { 
-            client, 
-            endpoint: DEFAULT_API_ENDPOINT.to_string() 
+
+        Self {
+            client,
+            endpoint: DEFAULT_API_ENDPOINT.to_string(),
         }
     }
 
@@ -77,7 +75,7 @@ impl DesecProvider {
             ..self
         }
     }
-    
+
     pub(crate) async fn create(
         &self,
         name: impl IntoFqdn<'_>,
@@ -163,7 +161,6 @@ impl DesecProvider {
     }
 }
 
-
 /// Converts a DNS record into a representation that can be sent to the desec API.
 impl From<DnsRecord> for DesecDnsRecordRepresentation {
     fn from(record: DnsRecord) -> Self {
@@ -192,7 +189,12 @@ impl From<DnsRecord> for DesecDnsRecordRepresentation {
                 record_type: "TXT".to_string(),
                 content,
             },
-            DnsRecord::SRV { content, priority, weight, port } => DesecDnsRecordRepresentation {
+            DnsRecord::SRV {
+                content,
+                priority,
+                weight,
+                port,
+            } => DesecDnsRecordRepresentation {
                 record_type: "SRV".to_string(),
                 content: format!("{priority} {weight} {port} {content}"),
             },

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -17,19 +17,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::{http::HttpClientBuilder, DnsRecord, IntoFqdn, strip_origin_from_name, DnsRecordType};
 
+pub struct DesecDnsRecordRepresentation {
+    pub record_type: String,
+    pub content: String,
+}
+
 #[derive(Clone)]
 pub struct DesecProvider {
     client: HttpClientBuilder,
     endpoint: String,
 }
 
-pub struct DesecDnsRecordRepresentation {
-    pub record_type: String,
-    pub content: String,
-}
-
+/// The parameters for creation and modification requests of the desec API.
 #[derive(Serialize, Clone, Debug)]
-pub struct CreateDnsRecordParams<'a> {
+pub struct DnsRecordParams<'a> {
     pub subname: &'a str,
     #[serde(rename = "type")]
     pub rr_type: &'a str,
@@ -37,15 +38,7 @@ pub struct CreateDnsRecordParams<'a> {
     pub records: Vec<String>,
 }
 
-#[derive(Serialize, Clone, Debug)]
-pub struct UpdateDnsRecordParams<'a> {
-    pub subname: &'a str,
-    #[serde(rename = "type")]
-    pub rr_type: &'a str,
-    pub ttl: Option<u32>,
-    pub records: Vec<String>,
-}
-
+/// The response for creation and modification requests of the desec API.
 #[derive(Deserialize, Debug)]
 pub struct DesecApiResponse {
     pub created: String,
@@ -98,7 +91,7 @@ impl DesecProvider {
                 subdomain = &subdomain,
                 rr_type = &desec_record.record_type,
             ))
-            .with_body(CreateDnsRecordParams {
+            .with_body(DnsRecordParams {
                 subname: &subdomain,
                 rr_type: &desec_record.record_type,
                 ttl: Some(ttl),
@@ -129,7 +122,7 @@ impl DesecProvider {
                 subdomain = &subdomain,
                 rr_type = &desec_record.record_type,
             ))
-            .with_body(UpdateDnsRecordParams {
+            .with_body(DnsRecordParams {
                 subname: &name,
                 rr_type: desec_record.record_type.as_str(),
                 ttl: Some(ttl),
@@ -166,6 +159,7 @@ impl DesecProvider {
 }
 
 
+/// Converts a DNS record into a representation that can be sent to the desec API.
 impl From<DnsRecord> for DesecDnsRecordRepresentation {
     fn from(record: DnsRecord) -> Self {
         match record {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -13,6 +13,7 @@ use crate::DnsRecord;
 
 pub mod cloudflare;
 pub mod digitalocean;
+pub mod desec;
 pub mod rfc2136;
 
 impl DnsRecord {

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -1,13 +1,12 @@
 #[cfg(test)]
 mod tests {
-    use crate::{providers::desec::DesecProvider, DnsRecord, DnsRecordType, Error};
-    use std::time::Duration;
-    use serde_json::json;
     use crate::providers::desec::DesecDnsRecordRepresentation;
+    use crate::{providers::desec::DesecProvider, DnsRecord, DnsRecordType, Error};
+    use serde_json::json;
+    use std::time::Duration;
 
     fn setup_provider(endpoint: &str) -> DesecProvider {
-        DesecProvider::new("test_token", Some(Duration::from_secs(1)))
-            .with_endpoint(endpoint)
+        DesecProvider::new("test_token", Some(Duration::from_secs(1))).with_endpoint(endpoint)
     }
 
     #[tokio::test]
@@ -20,7 +19,8 @@ mod tests {
             "records": ["1.1.1.1"],
         });
 
-        let mock = server.mock("POST", "/domains/example.com/rrsets/")
+        let mock = server
+            .mock("POST", "/domains/example.com/rrsets/")
             .with_status(201)
             .with_header("content-type", "application/json")
             .match_header("authorization", "Token test_token")
@@ -36,7 +36,7 @@ mod tests {
                     "ttl": 3600,
                     "type": "A",
                     "touched": "2025-07-25T19:18:37.292390Z"
-                }"#
+                }"#,
             )
             .create();
 
@@ -44,7 +44,9 @@ mod tests {
         let result = provider
             .create(
                 "test.example.com",
-                DnsRecord::A { content: "1.1.1.1".parse().unwrap() },
+                DnsRecord::A {
+                    content: "1.1.1.1".parse().unwrap(),
+                },
                 3600,
                 "example.com",
             )
@@ -64,7 +66,8 @@ mod tests {
             "records": ["10 mail.example.com"],
         });
 
-        let mock = server.mock("POST", "/domains/example.com/rrsets/")
+        let mock = server
+            .mock("POST", "/domains/example.com/rrsets/")
             .with_status(201)
             .with_header("content-type", "application/json")
             .match_header("authorization", "Token test_token")
@@ -80,7 +83,7 @@ mod tests {
                     "ttl": 3600,
                     "type": "MX",
                     "touched": "2025-07-25T19:18:37.292390Z"
-                }"#
+                }"#,
             )
             .create();
 
@@ -88,7 +91,10 @@ mod tests {
         let result = provider
             .create(
                 "test.example.com",
-                DnsRecord::MX { priority: 10, content: "mail.example.com".to_string() },
+                DnsRecord::MX {
+                    priority: 10,
+                    content: "mail.example.com".to_string(),
+                },
                 3600,
                 "example.com",
             )
@@ -108,7 +114,8 @@ mod tests {
             "records": ["1.1.1.1"],
         });
 
-        let mock = server.mock("POST", "/domains/example.com/rrsets/")
+        let mock = server
+            .mock("POST", "/domains/example.com/rrsets/")
             .with_status(401)
             .with_header("content-type", "application/json")
             .match_header("authorization", "Token test_token")
@@ -121,7 +128,9 @@ mod tests {
         let result = provider
             .create(
                 "test.example.com",
-                DnsRecord::A { content: "1.1.1.1".parse().unwrap() },
+                DnsRecord::A {
+                    content: "1.1.1.1".parse().unwrap(),
+                },
                 3600,
                 "example.com",
             )
@@ -141,7 +150,8 @@ mod tests {
             "records": ["2001:db8::1"],
         });
 
-        let mock = server.mock("PUT", "/domains/example.com/rrsets/test/AAAA/")
+        let mock = server
+            .mock("PUT", "/domains/example.com/rrsets/test/AAAA/")
             .with_status(200)
             .match_body(mockito::Matcher::Json(expected_request))
             .match_header("authorization", "Token test_token")
@@ -155,7 +165,7 @@ mod tests {
                     "ttl": 3600,
                     "type": "AAAA",
                     "touched": "2025-07-25T19:18:37.292390Z"
-                }"#
+                }"#,
             )
             .create();
 
@@ -163,7 +173,9 @@ mod tests {
         let result = provider
             .update(
                 "test",
-                DnsRecord::AAAA { content: "2001:db8::1".parse().unwrap() },
+                DnsRecord::AAAA {
+                    content: "2001:db8::1".parse().unwrap(),
+                },
                 3600,
                 "example.com",
             )
@@ -176,19 +188,16 @@ mod tests {
     #[tokio::test]
     async fn test_delete_record_success() {
         let mut server = mockito::Server::new_async().await;
-        let mock = server.mock("DELETE", "/domains/example.com/rrsets/test/TXT/")
+        let mock = server
+            .mock("DELETE", "/domains/example.com/rrsets/test/TXT/")
             .with_status(204)
             .create();
-    
+
         let provider = setup_provider(server.url().as_str());
         let result = provider
-            .delete(
-                "test",
-                "example.com",
-                DnsRecordType::TXT,
-            )
+            .delete("test", "example.com", DnsRecordType::TXT)
             .await;
-    
+
         assert!(result.is_ok());
         mock.assert();
     }
@@ -196,14 +205,22 @@ mod tests {
     #[tokio::test]
     #[ignore = "Requires desec API Token and domain configuration"]
     async fn integration_test() {
-        let token = "";        // <-- Fill in your deSEC API token here
-        let origin = "";       // <-- Fill in your domain (e.g., "example.com")
-        let domain = "";       // <-- Fill in your test subdomain (e.g., "test.example.com")
+        let token = ""; // <-- Fill in your deSEC API token here
+        let origin = ""; // <-- Fill in your domain (e.g., "example.com")
+        let domain = ""; // <-- Fill in your test subdomain (e.g., "test.example.com")
 
-        assert!(!token.is_empty(), "Please configure your deSEC API token in the integration test");
-        assert!(!origin.is_empty(), "Please configure your domain in the integration test");
-        assert!(!domain.is_empty(), "Please configure your test subdomain in the integration test");
-
+        assert!(
+            !token.is_empty(),
+            "Please configure your deSEC API token in the integration test"
+        );
+        assert!(
+            !origin.is_empty(),
+            "Please configure your domain in the integration test"
+        );
+        assert!(
+            !domain.is_empty(),
+            "Please configure your test subdomain in the integration test"
+        );
 
         let provider = DesecProvider::new(token, Some(Duration::from_secs(30)));
 
@@ -211,34 +228,32 @@ mod tests {
         let creation_result = provider
             .create(
                 domain,
-                DnsRecord::A { content: "1.1.1.1".parse().unwrap() },
+                DnsRecord::A {
+                    content: "1.1.1.1".parse().unwrap(),
+                },
                 3600,
-                origin
+                origin,
             )
             .await;
 
         assert!(creation_result.is_ok());
 
-       // check modification
+        // check modification
         let update_result = provider
             .update(
                 domain,
-                DnsRecord::A { content: "2.2.2.2".parse().unwrap() },
+                DnsRecord::A {
+                    content: "2.2.2.2".parse().unwrap(),
+                },
                 3600,
-                origin
+                origin,
             )
             .await;
 
         assert!(update_result.is_ok());
 
         // check deletion
-        let deletion_result = provider
-            .delete(
-                domain,
-                origin,
-                DnsRecordType::A,
-            )
-            .await;
+        let deletion_result = provider.delete(domain, origin, DnsRecordType::A).await;
 
         assert!(deletion_result.is_ok());
     }

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -6,7 +6,8 @@ mod tests {
     use crate::providers::desec::DesecDnsRecordRepresentation;
 
     fn setup_provider(endpoint: &str) -> DesecProvider {
-        DesecProvider::new("test_token", Some(endpoint), Some(Duration::from_secs(1)))
+        DesecProvider::new("test_token", Some(Duration::from_secs(1)))
+            .with_endpoint(endpoint)
     }
 
     #[tokio::test]

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -1,0 +1,155 @@
+#[cfg(test)]
+mod tests {
+    use crate::{providers::desec::DesecProvider, DnsRecord, DnsRecordType, Error};
+    use std::time::Duration;
+
+    fn setup_provider(endpoint: &str) -> DesecProvider {
+        DesecProvider::new("test_token", Some(endpoint),  Some(Duration::from_secs(1)))
+    }
+
+    #[tokio::test]
+    async fn test_create_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("POST", "/domains/example.com/rrsets/test/A/")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_header("authorization", "Token test_token")
+            .with_body(
+            r#"{
+                    "created": "2025-07-25T19:18:37.286381Z",
+                    "domain": "example.com",
+                    "subname": "test",
+                    "name": "test.example.com.",
+                    "records": [
+                        "1.1.1.1"
+                    ],
+                    "ttl": 3600,
+                    "type": "A",
+                    "touched": "2025-07-25T19:18:37.292390Z"
+                }"#
+            )
+            .create();
+
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::A { content: "1.1.1.1".parse().unwrap() },
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+       mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_create_record_unauthorized() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("POST", "/domains/example.com/rrsets/test/A/")
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_header("authorization", "Token test_token")
+            .with_body(r#"{ "detail": "Invalid token." }"#
+            )
+            .create();
+
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .create(
+                "test",
+                DnsRecord::A { content: "1.1.1.1".parse().unwrap() },
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::Unauthorized)));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_update_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server.mock("PUT", "/domains/example.com/rrsets/test/AAAA/")
+            .with_status(200)
+            .with_body(
+                r#"{
+                    "created": "2025-07-25T19:18:37.286381Z",
+                    "domain": "example.com",
+                    "subname": "test",
+                    "name": "test.example.com.",
+                    "records": [
+                        "2001:db8::1"
+                    ],
+                    "ttl": 3600,
+                    "type": "AAAA",
+                    "touched": "2025-07-25T19:18:37.292390Z"
+                }"#
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .update(
+                "test",
+                DnsRecord::AAAA { content: "2001:db8::1".parse().unwrap() },
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+
+#[tokio::test]
+async fn test_delete_record_success() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("DELETE", "/domains/example.com/rrsets/test/TXT/")
+        .with_status(204)
+        .create();
+
+    let provider = setup_provider(server.url().as_str());
+    let result = provider
+        .delete(
+            "test",
+            "example.com",
+            DnsRecordType::TXT,
+        )
+        .await;
+
+    assert!(result.is_ok());
+    mock.assert();
+}
+
+    /*
+#[test]
+fn test_convert_record() {
+use super::convert_record;
+
+// Test A record
+let record = DnsRecord::A { content: "192.0.2.1".parse().unwrap() };
+assert_eq!(convert_record(record).unwrap(), "192.0.2.1");
+
+// Test MX record
+let record = DnsRecord::MX {
+    content: "mail.example.com".to_string(),
+    priority: 10,
+};
+assert_eq!(convert_record(record).unwrap(), "10 mail.example.com");
+
+// Test SRV record
+let record = DnsRecord::SRV {
+    content: "sip.example.com".to_string(),
+    priority: 10,
+    weight: 20,
+    port: 5060,
+};
+assert_eq!(convert_record(record).unwrap(), "10 20 5060 sip.example.com");
+}*/
+}

--- a/src/tests/lib_tests.rs
+++ b/src/tests/lib_tests.rs
@@ -1,0 +1,26 @@
+
+
+#[cfg(test)]
+mod tests {
+    use crate::{strip_origin_from_name};
+
+    #[test]
+    fn test_strip_origin_from_name() {
+        assert_eq!(
+            strip_origin_from_name("www.example.com", "example.com"),
+            "www"
+        );
+        assert_eq!(
+            strip_origin_from_name("example.com", "example.com"),
+            "@"
+        );
+        assert_eq!(
+            strip_origin_from_name("api.v1.example.com", "example.com"),
+            "api.v1"
+        );
+        assert_eq!(
+            strip_origin_from_name("example.com", "google.com"),
+            "example.com"
+        );
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright Stalwart Labs Ltd. See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+pub mod lib_tests;
+pub mod desec_tests;


### PR DESCRIPTION
This PR adds support for the German DNS service [deSEC](https://desec.io). Besides the actual implementation of the provider itself, I've modified and extended some parts of the general library.

The deSEC provider is unit tested with mockito and tokio. I also added a manual integration test to check the implementation against the real API.

As this is my first real rust implementation, I may not have followed all best practices and made some rookie mistakes. 

1. I extended the http client with a `send_with_retry` method to support the rate limiting of the desec API, signaled by the 429 return code
2. I added support for code 204 (No Content) 
3. I added a `DnsRecordType` enum, for the DnsUpdater delete method
4. I added [strum_macros](https://crates.io/crates/strum_macros) to simplify the creation of string representations of the `DnsRecordType` and `DnsRecord
5. I moved the `strip_origin_from_name` from the `digitalocean` provider to the lib, as I also need it in the `desec` implementation
6. I created a test module where I created a the deSEC test code and the library test code
7. I annotated the code snippets in the `README.md` to be ignored by `cargo test` 