### PR TITLE
Add std::error:Error trait to dns-update::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,8 @@ impl FromStr for TsigAlgorithm {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
To comply with the standard and make dns-update::Error more manageable in projects with multiple Error structs, implement the trait std::error::Error is neccesary. Only adding this line the project can be aligned with the rust ecosystem in this aspect