### PR TITLE
Add support for Porkbun (porkbun.com)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use providers::{
     cloudflare::CloudflareProvider,
     desec::DesecProvider,
     digitalocean::DigitalOceanProvider,
+    porkbun::PorkBunProvider,
     rfc2136::{DnsAddress, Rfc2136Provider},
 };
 
@@ -125,6 +126,7 @@ pub enum DnsUpdater {
     #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
     Ovh(OvhProvider),
     Bunny(BunnyProvider),
+    Porkbun(PorkBunProvider),
 }
 
 pub trait IntoFqdn<'x> {
@@ -217,6 +219,18 @@ impl DnsUpdater {
         Ok(DnsUpdater::Bunny(BunnyProvider::new(api_key, timeout)?))
     }
 
+    pub fn new_porkbun(
+        api_key: impl AsRef<str>,
+        secret_api_key: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> crate::Result<Self> {
+        Ok(DnsUpdater::Porkbun(PorkBunProvider::new(
+            api_key,
+            secret_api_key,
+            timeout,
+        )))
+    }
+
     /// Create a new DNS record.
     pub async fn create(
         &self,
@@ -233,6 +247,7 @@ impl DnsUpdater {
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Bunny(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Porkbun(provider) => provider.create(name, record, ttl, origin).await,
         }
     }
 
@@ -252,6 +267,7 @@ impl DnsUpdater {
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Bunny(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Porkbun(provider) => provider.update(name, record, ttl, origin).await,
         }
     }
 
@@ -270,6 +286,7 @@ impl DnsUpdater {
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Bunny(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::Porkbun(provider) => provider.delete(name, origin, record).await,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,12 +320,14 @@ impl<'x> IntoFqdn<'x> for String {
     }
 }
 
-pub fn strip_origin_from_name(name: &str, origin: &str) -> String {
+/// Strip `name` from `origin`, return `return_if_equal` if `name` is the same
+/// as `origin`, or  `@` if `None` given.
+pub fn strip_origin_from_name(name: &str, origin: &str, return_if_equal: Option<&str>) -> String {
     let name = name.trim_end_matches('.');
     let origin = origin.trim_end_matches('.');
 
     if name == origin {
-        return "@".to_string();
+        return return_if_equal.unwrap_or("@").to_string();
     }
 
     if name.ends_with(&format!(".{}", origin)) {

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -85,7 +85,7 @@ impl DesecProvider {
     ) -> crate::Result<()> {
         let name = name.into_name();
         let domain = origin.into_name();
-        let subdomain = strip_origin_from_name(&name, &domain);
+        let subdomain = strip_origin_from_name(&name, &domain, None);
 
         let desec_record = DesecDnsRecordRepresentation::from(record);
         self.client
@@ -114,7 +114,7 @@ impl DesecProvider {
     ) -> crate::Result<()> {
         let name = name.into_name();
         let domain = origin.into_name();
-        let subdomain = strip_origin_from_name(&name, &domain);
+        let subdomain = strip_origin_from_name(&name, &domain, None);
 
         let desec_record = DesecDnsRecordRepresentation::from(record);
         self.client
@@ -144,7 +144,7 @@ impl DesecProvider {
     ) -> crate::Result<()> {
         let name = name.into_name();
         let domain = origin.into_name();
-        let subdomain = strip_origin_from_name(&name, &domain);
+        let subdomain = strip_origin_from_name(&name, &domain, None);
 
         let rr_type = &record_type.to_string();
         self.client

--- a/src/providers/digitalocean.rs
+++ b/src/providers/digitalocean.rs
@@ -97,7 +97,7 @@ impl DigitalOceanProvider {
     ) -> crate::Result<()> {
         let name = name.into_name();
         let domain = origin.into_name();
-        let subdomain = strip_origin_from_name(&name, &domain);
+        let subdomain = strip_origin_from_name(&name, &domain, None);
 
         self.client
             .post(format!(
@@ -122,7 +122,7 @@ impl DigitalOceanProvider {
     ) -> crate::Result<()> {
         let name = name.into_name();
         let domain = origin.into_name();
-        let subdomain = strip_origin_from_name(&name, &domain);
+        let subdomain = strip_origin_from_name(&name, &domain, None);
         let record_id = self.obtain_record_id(&name, &domain).await?;
 
         self.client
@@ -158,7 +158,7 @@ impl DigitalOceanProvider {
     }
 
     async fn obtain_record_id(&self, name: &str, domain: &str) -> crate::Result<i64> {
-        let subdomain = strip_origin_from_name(name, domain);
+        let subdomain = strip_origin_from_name(name, domain, None);
         self.client
             .get(format!(
                 "https://api.digitalocean.com/v2/domains/{domain}/records?{}",

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -16,6 +16,7 @@ pub mod cloudflare;
 pub mod desec;
 pub mod digitalocean;
 pub mod ovh;
+pub mod porkbun;
 pub mod rfc2136;
 
 impl DnsRecord {

--- a/src/providers/ovh.rs
+++ b/src/providers/ovh.rs
@@ -216,7 +216,7 @@ impl OvhProvider {
         record_type: &str,
     ) -> crate::Result<u64> {
         let name = name.into_name();
-        let subdomain = strip_origin_from_name(&name, zone);
+        let subdomain = strip_origin_from_name(&name, zone, None);
         let subdomain = if subdomain == "@" { "" } else { &subdomain };
 
         let url = format!(
@@ -256,7 +256,7 @@ impl OvhProvider {
     ) -> crate::Result<()> {
         let zone = self.get_zone_name(origin).await?;
         let name = name.into_name();
-        let subdomain = strip_origin_from_name(&name, &zone);
+        let subdomain = strip_origin_from_name(&name, &zone, None);
         let subdomain = if subdomain == "@" {
             String::new()
         } else {

--- a/src/providers/porkbun.rs
+++ b/src/providers/porkbun.rs
@@ -1,0 +1,255 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use crate::{http::HttpClientBuilder, strip_origin_from_name, DnsRecord, Error, IntoFqdn};
+use serde::{Deserialize, Serialize};
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    time::Duration,
+};
+
+#[derive(Clone)]
+pub struct PorkBunProvider {
+    client: HttpClientBuilder,
+    api_key: String,
+    secret_api_key: String,
+    endpoint: String,
+}
+
+/// The parameters for authenticating requests to the Porkbun API.
+#[derive(Serialize, Debug)]
+pub struct AuthParams<'a> {
+    pub secretapikey: &'a str,
+    pub apikey: &'a str,
+}
+
+/// The parameters for create and update requests to the Porkbun API.
+// Note: there are some fields in this struct that are only needed when
+// creating a new record, not when modifying an existing one, we use the same
+// struct for both operations because it simplifies the code and the extra
+// fields are simply ignored by the API during an update operation.
+#[derive(Serialize, Debug)]
+pub struct DnsRecordParams<'a> {
+    #[serde(flatten)]
+    pub auth: AuthParams<'a>,
+    pub name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<&'a str>,
+    #[serde(flatten)]
+    content: RecordData,
+}
+
+/// The response for create and update requests to the Porkbun API.
+#[derive(Deserialize, Debug)]
+pub struct ApiResponse {
+    pub status: String,
+    pub message: Option<String>,
+}
+
+// Note: some of these types are not supported at the `dns-update` library
+// level, but we include them here for completeness.
+#[derive(Serialize, Clone, Debug)]
+#[serde(tag = "type")]
+#[allow(clippy::upper_case_acronyms)]
+pub enum RecordData {
+    A { content: Ipv4Addr },
+    MX { content: String, prio: u16 },
+    CNAME { content: String },
+    ALIAS { content: String },
+    TXT { content: String },
+    NS { content: String },
+    AAAA { content: Ipv6Addr },
+    SRV { content: String, prio: u16 },
+    TLSA { content: String },
+    CAA { content: String },
+    HTTPS { content: String },
+    SVCB { content: String },
+    SSHFP { content: String },
+}
+
+/// The default endpoint for the Porkbun API.
+const DEFAULT_API_ENDPOINT: &str = "https://api.porkbun.com/api/json/v3";
+
+impl PorkBunProvider {
+    pub(crate) fn new(
+        api_key: impl AsRef<str>,
+        secret_api_key: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> Self {
+        let client = HttpClientBuilder::default().with_timeout(timeout);
+
+        Self {
+            client,
+            api_key: api_key.as_ref().to_string(),
+            secret_api_key: secret_api_key.as_ref().to_string(),
+            endpoint: DEFAULT_API_ENDPOINT.to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_endpoint(self, endpoint: impl AsRef<str>) -> Self {
+        Self {
+            endpoint: endpoint.as_ref().to_string(),
+            ..self
+        }
+    }
+
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let domain = origin.into_name();
+        let subdomain = strip_origin_from_name(&name, &domain, Some(""));
+
+        self.client
+            .post(format!(
+                "{endpoint}/dns/create/{domain}",
+                endpoint = self.endpoint,
+                domain = domain
+            ))
+            .with_body(DnsRecordParams {
+                auth: AuthParams {
+                    secretapikey: &self.secret_api_key,
+                    apikey: &self.api_key,
+                },
+                name: &subdomain,
+                ttl: Some(ttl),
+                notes: None,
+                content: record.into(),
+            })?
+            .send_with_retry::<ApiResponse>(3)
+            .await?
+            .into_result()
+    }
+
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let domain = origin.into_name();
+        let subdomain = strip_origin_from_name(&name, &domain, Some(""));
+        let content: RecordData = record.into();
+
+        self.client
+            .post(format!(
+                "{endpoint}/dns/editByNameType/{domain}/{type}/{subdomain}",
+                endpoint = self.endpoint,
+                domain = domain,
+                type = content.variant_name(),
+                subdomain = subdomain,
+            ))
+            .with_body(DnsRecordParams {
+                auth: AuthParams {
+                    secretapikey: &self.secret_api_key,
+                    apikey: &self.api_key,
+                },
+                name: &subdomain,
+                ttl: Some(ttl),
+                notes: None,
+                content,
+            })?
+            .send_with_retry::<ApiResponse>(3)
+            .await?
+            .into_result()
+    }
+
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        origin: impl IntoFqdn<'_>,
+        record_type: crate::DnsRecordType,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let domain = origin.into_name();
+        let subdomain = strip_origin_from_name(&name, &domain, Some(""));
+
+        self.client
+            .post(format!(
+                "{endpoint}/dns/deleteByNameType/{domain}/{type}/{subdomain}",
+                endpoint = self.endpoint,
+                domain = domain,
+                type = record_type.to_string(),
+                subdomain = subdomain,
+            ))
+            .with_body(AuthParams {
+                secretapikey: &self.secret_api_key,
+                apikey: &self.api_key,
+            })?
+            .send_with_retry::<ApiResponse>(3)
+            .await?
+            .into_result()
+    }
+}
+
+impl ApiResponse {
+    fn into_result(self) -> crate::Result<()> {
+        if self.status == "SUCCESS" {
+            Ok(())
+        } else {
+            Err(Error::Api(self.message.unwrap_or(self.status)))
+        }
+    }
+}
+
+impl RecordData {
+    pub fn variant_name(&self) -> &'static str {
+        match self {
+            RecordData::A { .. } => "A",
+            RecordData::MX { .. } => "MX",
+            RecordData::CNAME { .. } => "CNAME",
+            RecordData::ALIAS { .. } => "ALIAS",
+            RecordData::TXT { .. } => "TXT",
+            RecordData::NS { .. } => "NS",
+            RecordData::AAAA { .. } => "AAAA",
+            RecordData::SRV { .. } => "SRV",
+            RecordData::TLSA { .. } => "TLSA",
+            RecordData::CAA { .. } => "CAA",
+            RecordData::HTTPS { .. } => "HTTPS",
+            RecordData::SVCB { .. } => "SVCB",
+            RecordData::SSHFP { .. } => "SSHFP",
+        }
+    }
+}
+
+impl From<DnsRecord> for RecordData {
+    fn from(record: DnsRecord) -> Self {
+        match record {
+            DnsRecord::A { content } => RecordData::A { content },
+            DnsRecord::AAAA { content } => RecordData::AAAA { content },
+            DnsRecord::CNAME { content } => RecordData::CNAME { content },
+            DnsRecord::NS { content } => RecordData::NS { content },
+            DnsRecord::MX { content, priority } => RecordData::MX {
+                content,
+                prio: priority,
+            },
+            DnsRecord::TXT { content } => RecordData::TXT { content },
+            DnsRecord::SRV {
+                content,
+                priority,
+                weight,
+                port,
+            } => RecordData::SRV {
+                content: format!("{weight} {port} {content}"),
+                prio: priority,
+            },
+        }
+    }
+}

--- a/src/tests/lib_tests.rs
+++ b/src/tests/lib_tests.rs
@@ -1,20 +1,24 @@
 #[test]
 fn test_strip_origin_from_name() {
     assert_eq!(
-        crate::strip_origin_from_name("www.example.com", "example.com"),
+        crate::strip_origin_from_name("www.example.com", "example.com", None),
         "www"
     );
     assert_eq!(
-        crate::strip_origin_from_name("example.com", "example.com"),
+        crate::strip_origin_from_name("example.com", "example.com", None),
         "@"
     );
     assert_eq!(
-        crate::strip_origin_from_name("api.v1.example.com", "example.com"),
+        crate::strip_origin_from_name("api.v1.example.com", "example.com", None),
         "api.v1"
     );
     assert_eq!(
-        crate::strip_origin_from_name("example.com", "google.com"),
+        crate::strip_origin_from_name("example.com", "google.com", None),
         "example.com"
+    );
+    assert_eq!(
+        strip_origin_from_name("example.com", "example.com", Some("")),
+        ""
     );
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,3 +14,4 @@ pub mod desec_tests;
 #[cfg(test)]
 pub mod lib_tests;
 pub mod ovh_tests;
+pub mod porkbun_tests;

--- a/src/tests/porkbun_tests.rs
+++ b/src/tests/porkbun_tests.rs
@@ -1,0 +1,288 @@
+// /*
+//  * Copyright Stalwart Labs LLC See the COPYING
+//  * file at the top-level directory of this distribution.
+//  *
+//  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+//  * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+//  * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+//  * option. This file may not be copied, modified, or distributed
+//  * except according to those terms.
+//  */
+#[cfg(test)]
+mod tests {
+    use crate::{
+        providers::porkbun::{PorkBunProvider, RecordData},
+        DnsRecord, DnsRecordType, DnsUpdater,
+    };
+    use serde_json::json;
+    use std::{
+        net::{Ipv4Addr, Ipv6Addr},
+        time::Duration,
+    };
+
+    fn setup_provider(endpoint: &str) -> PorkBunProvider {
+        PorkBunProvider::new(
+            "test_api_key",
+            "test_secret_api_key",
+            Some(Duration::from_secs(1)),
+        )
+        .with_endpoint(endpoint)
+    }
+
+    #[test]
+    fn dns_updater_creation() {
+        let updater = DnsUpdater::new_porkbun(
+            "test_api_key-mock-api-key",
+            "test_secret_api_key",
+            Some(Duration::from_secs(30)),
+        );
+
+        assert!(updater.is_ok());
+
+        assert!(
+            matches!(updater, Ok(DnsUpdater::Porkbun(..))),
+            "Expected Porkbun updater to provide a Porkbun provider"
+        );
+    }
+
+    #[test]
+    fn record_data_from_dns_record() {
+        let record = DnsRecord::A {
+            content: "1.1.1.1".parse().unwrap(),
+        };
+
+        let porkbun_record: RecordData = record.into();
+        if let RecordData::A { content } = porkbun_record {
+            assert_eq!(content, "1.1.1.1".parse::<Ipv4Addr>().unwrap());
+        } else {
+            panic!("Expected A type record, got {:?}", porkbun_record);
+        }
+        assert_eq!(porkbun_record.variant_name(), "A");
+
+        let record = DnsRecord::AAAA {
+            content: "2001:db8::1".parse().unwrap(),
+        };
+        let porkbun_record: RecordData = record.into();
+        if let RecordData::AAAA { content } = porkbun_record {
+            assert_eq!(content, "2001:db8::1".parse::<Ipv6Addr>().unwrap());
+        } else {
+            panic!("Expected AAAA type record, got {:?}", porkbun_record);
+        }
+        assert_eq!(porkbun_record.variant_name(), "AAAA");
+
+        let record = DnsRecord::CNAME {
+            content: "alias.example.com".to_string(),
+        };
+        let porkbun_record: RecordData = record.into();
+        if let RecordData::CNAME { ref content } = porkbun_record {
+            assert_eq!(content, "alias.example.com");
+        } else {
+            panic!("Expected CNAME type record, got {:?}", porkbun_record);
+        }
+        assert_eq!(porkbun_record.variant_name(), "CNAME");
+
+        let record = DnsRecord::MX {
+            priority: 10,
+            content: "mail.example.com".to_string(),
+        };
+        let porkbun_record: RecordData = record.into();
+        if let RecordData::MX { prio, ref content } = porkbun_record {
+            assert_eq!(prio, 10);
+            assert_eq!(content, "mail.example.com");
+        } else {
+            panic!("Expected MX type record, got {:?}", porkbun_record);
+        }
+        assert_eq!(porkbun_record.variant_name(), "MX");
+
+        let record = DnsRecord::TXT {
+            content: "v=spf1 include:_spf.example.com ~all".to_string(),
+        };
+        let porkbun_record: RecordData = record.into();
+        if let RecordData::TXT { ref content } = porkbun_record {
+            assert_eq!(content, "v=spf1 include:_spf.example.com ~all");
+        } else {
+            panic!("Expected TXT type record, got {:?}", porkbun_record);
+        }
+        assert_eq!(porkbun_record.variant_name(), "TXT");
+
+        let record = DnsRecord::SRV {
+            priority: 10,
+            weight: 20,
+            port: 443,
+            content: "sip.example.com".to_string(),
+        };
+        let porkbun_record: RecordData = record.into();
+        if let RecordData::SRV { prio, ref content } = porkbun_record {
+            assert_eq!(prio, 10);
+            assert_eq!(content, "20 443 sip.example.com");
+        } else {
+            panic!("Expected SRV type record, got {:?}", porkbun_record);
+        }
+        assert_eq!(porkbun_record.variant_name(), "SRV");
+
+        let record = DnsRecord::NS {
+            content: "ns1.example.com".to_string(),
+        };
+        let porkbun_record: RecordData = record.into();
+        if let RecordData::NS { ref content } = porkbun_record {
+            assert_eq!(content, "ns1.example.com");
+        } else {
+            panic!("Expected NS type record, got {:?}", porkbun_record);
+        }
+        assert_eq!(porkbun_record.variant_name(), "NS");
+    }
+
+    #[tokio::test]
+    async fn create_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/dns/create/example.com")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "apikey": "test_api_key",
+                "secretapikey": "test_secret_api_key",
+                "name": "test",
+                "type": "A",
+                "content": "1.1.1.1",
+                "ttl": 3600,
+            })))
+            .with_body(r#"{"status": "SUCCESS","id": "106926659"}"#)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::A {
+                    content: "1.1.1.1".parse().unwrap(),
+                },
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn update_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/dns/editByNameType/example.com/AAAA/www")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "apikey": "test_api_key",
+                "secretapikey": "test_secret_api_key",
+                "name": "www",
+                "type": "AAAA",
+                "content": "2001:db8::1",
+                "ttl": 3600,
+            })))
+            .with_body(r#"{"status": "SUCCESS"}"#)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .update(
+                "www.example.com",
+                DnsRecord::AAAA {
+                    content: "2001:db8::1".parse().unwrap(),
+                },
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/dns/deleteByNameType/example.com/TXT/test")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "apikey": "test_api_key",
+                "secretapikey": "test_secret_api_key",
+            })))
+            .with_body(r#"{"status": "SUCCESS"}"#)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .delete("test.example.com", "example.com", DnsRecordType::TXT)
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Porkbun API credentials and domain configuration"]
+    async fn integration_test() {
+        let api_key = std::env::var("PB_API_KEY").unwrap_or_default();
+        let secret_api_key = std::env::var("PB_SECRET_API_KEY").unwrap_or_default();
+        let origin = std::env::var("PB_ORIGIN").unwrap_or_default();
+        let domain = std::env::var("PB_DOMAIN").unwrap_or_default();
+
+        assert!(
+            !api_key.is_empty(),
+            "Please configure your Porkbun API key in the integration test"
+        );
+        assert!(
+            !secret_api_key.is_empty(),
+            "Please configure your Porkbun secret API key in the integration test"
+        );
+        assert!(
+            !origin.is_empty(),
+            "Please configure your domain in the integration test"
+        );
+        assert!(
+            !domain.is_empty(),
+            "Please configure your test domain in the integration test"
+        );
+
+        let updater =
+            DnsUpdater::new_porkbun(api_key, secret_api_key, Some(Duration::from_secs(30)))
+                .unwrap();
+
+        let creation_result = updater
+            .create(
+                &domain,
+                DnsRecord::A {
+                    content: "1.1.1.1".parse().unwrap(),
+                },
+                3600,
+                &origin,
+            )
+            .await;
+
+        assert!(creation_result.is_ok());
+
+        let update_result = updater
+            .update(
+                &domain,
+                DnsRecord::A {
+                    content: "2.2.2.2".parse().unwrap(),
+                },
+                3600,
+                &origin,
+            )
+            .await;
+
+        assert!(update_result.is_ok());
+
+        let deletion_result = updater.delete(domain, origin, DnsRecordType::A).await;
+
+        assert!(deletion_result.is_ok());
+    }
+}


### PR DESCRIPTION
Hi,

This PR adds support for Porkbun's API.

Since they use `""` to indicate the root of the domain (instead of `@`), the first commit modifies the `strip_origin_from_name()` function in the library itself so that the provider can indicate while calling it which value should be returned when `origin` equals `name`.

Regards,