### PR TITLE
feat: add DNSimple provider

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -144,8 +144,7 @@ impl HttpClient {
             .map_err(|err| Error::Api(format!("Failed to send request to {}: {err}", self.url)))?;
 
         match response.status().as_u16() {
-            204 => serde_json::from_str("{}")
-                .map_err(|err| Error::Serialize(format!("Failed to create empty response: {err}"))),
+            204 => Ok(String::new()),
             200..=299 => response.text().await.map_err(|err| {
                 Error::Api(format!("Failed to read response from {}: {err}", self.url))
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use providers::{
     cloudflare::CloudflareProvider,
     desec::DesecProvider,
     digitalocean::DigitalOceanProvider,
+    dnsimple::DNSimpleProvider,
     porkbun::PorkBunProvider,
     rfc2136::{DnsAddress, Rfc2136Provider},
 };
@@ -127,6 +128,7 @@ pub enum DnsUpdater {
     Ovh(OvhProvider),
     Bunny(BunnyProvider),
     Porkbun(PorkBunProvider),
+    DNSimple(DNSimpleProvider),
 }
 
 pub trait IntoFqdn<'x> {
@@ -231,6 +233,19 @@ impl DnsUpdater {
         )))
     }
 
+    /// Create a new DNS updater using the DNSimple API.
+    pub fn new_dnsimple(
+        auth_token: impl AsRef<str>,
+        account_id: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> crate::Result<Self> {
+        Ok(DnsUpdater::DNSimple(DNSimpleProvider::new(
+            auth_token,
+            account_id,
+            timeout,
+        )))
+    }
+
     /// Create a new DNS record.
     pub async fn create(
         &self,
@@ -248,6 +263,7 @@ impl DnsUpdater {
             DnsUpdater::Ovh(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Bunny(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Porkbun(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::DNSimple(provider) => provider.create(name, record, ttl, origin).await,
         }
     }
 
@@ -268,6 +284,7 @@ impl DnsUpdater {
             DnsUpdater::Ovh(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Bunny(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Porkbun(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::DNSimple(provider) => provider.update(name, record, ttl, origin).await,
         }
     }
 
@@ -287,6 +304,7 @@ impl DnsUpdater {
             DnsUpdater::Ovh(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Bunny(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Porkbun(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::DNSimple(provider) => provider.delete(name, origin, record).await,
         }
     }
 }

--- a/src/providers/dnsimple.rs
+++ b/src/providers/dnsimple.rs
@@ -1,0 +1,278 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use std::time::Duration;
+
+use crate::{http::HttpClientBuilder, strip_origin_from_name, DnsRecord, DnsRecordType, Error, IntoFqdn};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_ENDPOINT: &str = "https://api.dnsimple.com/v2";
+
+#[derive(Clone)]
+pub struct DNSimpleProvider {
+    client: HttpClientBuilder,
+    account_id: String,
+    endpoint: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ApiResponse<T> {
+    pub data: T,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct RecordEntry {
+    pub id: i64,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub record_type: String,
+    pub content: String,
+    pub ttl: u32,
+    pub priority: Option<u16>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct CreateRecordParams {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub record_type: String,
+    pub content: String,
+    pub ttl: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u16>,
+}
+
+#[derive(Serialize, Debug)]
+struct ListRecordsQuery<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    type_filter: &'a str,
+}
+
+#[derive(Serialize, Debug)]
+pub struct UpdateRecordParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u16>,
+}
+
+impl DNSimpleProvider {
+    pub(crate) fn new(
+        auth_token: impl AsRef<str>,
+        account_id: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> Self {
+        let client = HttpClientBuilder::default()
+            .with_header("Authorization", format!("Bearer {}", auth_token.as_ref()))
+            .with_timeout(timeout);
+        Self {
+            client,
+            account_id: account_id.as_ref().to_string(),
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_endpoint(self, endpoint: impl AsRef<str>) -> Self {
+        Self {
+            endpoint: endpoint.as_ref().to_string(),
+            ..self
+        }
+    }
+
+    fn base_url(&self) -> String {
+        format!("{}/{}/zones", self.endpoint, self.account_id)
+    }
+
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let zone = origin.into_name();
+        let subdomain = strip_origin_from_name(&name, &zone, Some(""));
+        let params = CreateRecordParams::from_record(&record, &subdomain, ttl);
+
+        self.client
+            .post(format!("{}/{}/records", self.base_url(), zone))
+            .with_body(params)?
+            .send_raw()
+            .await
+            .map(|_| ())
+    }
+
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let zone = origin.into_name();
+        let subdomain = strip_origin_from_name(&name, &zone, Some(""));
+        let record_type = record_type_str(&record);
+        let record_id = self
+            .obtain_record_id(&subdomain, &zone, record_type)
+            .await?;
+        let (content, priority) = record_content_and_priority(&record);
+
+        self.client
+            .patch(format!(
+                "{}/{}/records/{}",
+                self.base_url(),
+                zone,
+                record_id
+            ))
+            .with_body(UpdateRecordParams {
+                content: Some(content),
+                ttl: Some(ttl),
+                priority,
+            })?
+            .send_raw()
+            .await
+            .map(|_| ())
+    }
+
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        origin: impl IntoFqdn<'_>,
+        record_type: DnsRecordType,
+    ) -> crate::Result<()> {
+        let name = name.into_name();
+        let zone = origin.into_name();
+        let subdomain = strip_origin_from_name(&name, &zone, Some(""));
+        let type_str = record_type_to_str(record_type);
+        let record_id = self
+            .obtain_record_id(&subdomain, &zone, type_str)
+            .await?;
+
+        self.client
+            .delete(format!(
+                "{}/{}/records/{}",
+                self.base_url(),
+                zone,
+                record_id
+            ))
+            .send_raw()
+            .await
+            .map(|_| ())
+    }
+
+    async fn obtain_record_id(
+        &self,
+        subdomain: &str,
+        zone: &str,
+        record_type: &str,
+    ) -> crate::Result<i64> {
+        let query = ListRecordsQuery {
+            name: subdomain,
+            type_filter: record_type,
+        };
+        let url = format!(
+            "{}/{}/records?{}",
+            self.base_url(),
+            zone,
+            serde_urlencoded::to_string(query).unwrap_or_default()
+        );
+        self.client
+            .get(url)
+            .send_with_retry::<ApiResponse<Vec<RecordEntry>>>(3)
+            .await
+            .and_then(|response| {
+                response
+                    .data
+                    .into_iter()
+                    .find(|r| r.name == subdomain && r.record_type == record_type)
+                    .map(|r| r.id)
+                    .ok_or_else(|| {
+                        Error::Api(format!(
+                            "DNS record {} ({}) not found",
+                            subdomain, record_type
+                        ))
+                    })
+            })
+    }
+}
+
+fn record_type_str(record: &DnsRecord) -> &'static str {
+    match record {
+        DnsRecord::A { .. } => "A",
+        DnsRecord::AAAA { .. } => "AAAA",
+        DnsRecord::CNAME { .. } => "CNAME",
+        DnsRecord::NS { .. } => "NS",
+        DnsRecord::MX { .. } => "MX",
+        DnsRecord::TXT { .. } => "TXT",
+        DnsRecord::SRV { .. } => "SRV",
+    }
+}
+
+fn record_type_to_str(t: DnsRecordType) -> &'static str {
+    match t {
+        DnsRecordType::A => "A",
+        DnsRecordType::AAAA => "AAAA",
+        DnsRecordType::CNAME => "CNAME",
+        DnsRecordType::NS => "NS",
+        DnsRecordType::MX => "MX",
+        DnsRecordType::TXT => "TXT",
+        DnsRecordType::SRV => "SRV",
+    }
+}
+
+fn record_content_and_priority(record: &DnsRecord) -> (String, Option<u16>) {
+    match record {
+        DnsRecord::A { content } => (content.to_string(), None),
+        DnsRecord::AAAA { content } => (content.to_string(), None),
+        DnsRecord::CNAME { content } => (content.clone(), None),
+        DnsRecord::NS { content } => (content.clone(), None),
+        DnsRecord::MX { content, priority } => (content.clone(), Some(*priority)),
+        DnsRecord::TXT { content } => (content.clone(), None),
+        DnsRecord::SRV {
+            content,
+            priority,
+            weight,
+            port,
+        } => (format!("{weight} {port} {content}"), Some(*priority)),
+    }
+}
+
+impl CreateRecordParams {
+    fn from_record(record: &DnsRecord, name: &str, ttl: u32) -> Self {
+        let (content, priority) = match record {
+            DnsRecord::A { content } => (content.to_string(), None),
+            DnsRecord::AAAA { content } => (content.to_string(), None),
+            DnsRecord::CNAME { content } => (content.clone(), None),
+            DnsRecord::NS { content } => (content.clone(), None),
+            DnsRecord::MX { content, priority } => (content.clone(), Some(*priority)),
+            DnsRecord::TXT { content } => (content.clone(), None),
+            DnsRecord::SRV {
+                content,
+                priority,
+                weight,
+                port,
+            } => (format!("{weight} {port} {content}"), Some(*priority)),
+        };
+        CreateRecordParams {
+            name: name.to_string(),
+            record_type: record_type_str(record).to_string(),
+            content,
+            ttl,
+            priority,
+        }
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -15,6 +15,7 @@ pub mod bunny;
 pub mod cloudflare;
 pub mod desec;
 pub mod digitalocean;
+pub mod dnsimple;
 pub mod ovh;
 pub mod porkbun;
 pub mod rfc2136;

--- a/src/tests/dnsimple_tests.rs
+++ b/src/tests/dnsimple_tests.rs
@@ -1,0 +1,138 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        providers::dnsimple::DNSimpleProvider,
+        DnsRecord, DnsRecordType, DnsUpdater,
+    };
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn setup_provider(endpoint: &str) -> DNSimpleProvider {
+        DNSimpleProvider::new(
+            "test_bearer_token",
+            "1010",
+            Some(Duration::from_secs(1)),
+        )
+        .with_endpoint(endpoint)
+    }
+
+    #[test]
+    fn dns_updater_creation() {
+        let updater = DnsUpdater::new_dnsimple(
+            "test_token",
+            "1010",
+            Some(Duration::from_secs(30)),
+        );
+
+        assert!(updater.is_ok());
+        assert!(
+            matches!(updater, Ok(DnsUpdater::DNSimple(..))),
+            "Expected DNSimple updater to provide a DNSimple provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/1010/zones/example.com/records")
+            .match_header("Authorization", "Bearer test_bearer_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "name": "test",
+                "type": "A",
+                "content": "1.1.1.1",
+                "ttl": 3600,
+            })))
+            .with_status(201)
+            .with_body(r#"{"data":{"id":1,"zone_id":"example.com","name":"test","content":"1.1.1.1","ttl":3600,"type":"A","priority":null}}"#)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::A {
+                    content: "1.1.1.1".parse().unwrap(),
+                },
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn update_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let list_mock = server
+            .mock("GET", "/1010/zones/example.com/records")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("name".into(), "www".into()),
+                mockito::Matcher::UrlEncoded("type".into(), "AAAA".into()),
+            ]))
+            .with_body(r#"{"data":[{"id":42,"zone_id":"example.com","parent_id":null,"name":"www","content":"2001:db8::1","ttl":3600,"priority":null,"type":"AAAA","regions":["global"],"system_record":false}]}"#)
+            .create();
+
+        let patch_mock = server
+            .mock("PATCH", "/1010/zones/example.com/records/42")
+            .match_header("Authorization", "Bearer test_bearer_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "content": "2001:db8::2",
+                "ttl": 3600,
+            })))
+            .with_status(200)
+            .with_body(r#"{"data":{"id":42,"zone_id":"example.com","name":"www","content":"2001:db8::2","ttl":3600,"type":"AAAA","priority":null}}"#)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .update(
+                "www.example.com",
+                DnsRecord::AAAA {
+                    content: "2001:db8::2".parse().unwrap(),
+                },
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        list_mock.assert();
+        patch_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let list_mock = server
+            .mock("GET", "/1010/zones/example.com/records")
+            .match_query(mockito::Matcher::Any)
+            .with_body(r#"{"data":[{"id":99,"zone_id":"example.com","parent_id":null,"name":"test","content":"hello","ttl":3600,"priority":null,"type":"TXT","regions":["global"],"system_record":false}]}"#)
+            .create();
+
+        let delete_mock = server
+            .mock("DELETE", "/1010/zones/example.com/records/99")
+            .match_header("Authorization", "Bearer test_bearer_token")
+            .with_status(204)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .delete("test.example.com", "example.com", DnsRecordType::TXT)
+            .await;
+
+        assert!(result.is_ok());
+        list_mock.assert();
+        delete_mock.assert();
+    }
+}

--- a/src/tests/lib_tests.rs
+++ b/src/tests/lib_tests.rs
@@ -17,7 +17,7 @@ fn test_strip_origin_from_name() {
         "example.com"
     );
     assert_eq!(
-        strip_origin_from_name("example.com", "example.com", Some("")),
+        crate::strip_origin_from_name("example.com", "example.com", Some("")),
         ""
     );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod bunny_test;
 pub mod desec_tests;
+pub mod dnsimple_tests;
 #[cfg(test)]
 pub mod lib_tests;
 pub mod ovh_tests;


### PR DESCRIPTION
There's a trick around updating and deleting records, where DNSimple identifies records by an abstract id and therefore we need to find it first. Otherwise this should be rather idiomatic I believe.

Disclaimer: this is my first ever Rust PR and I'm entirely unsure of what I'm doing, hopefully I could just nicely follow the pattern from other providers and it all makes sense 😃