### PR TITLE
initial route53 provider contribution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,17 @@ test_provider = []
 tokio = { version = "1.51", features = ["rt", "net"] }
 hickory-client = { version = "0.25", default-features = false }
 serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.116"
+serde_json = { version = "1.0.116", default-features = false, features = ["std"] }
 reqwest = { version = "0.13", default-features = false, features = ["http2", "gzip", "deflate"]}
-serde_urlencoded = "0.7.1"
+serde_urlencoded = { version = "0.7.1", default-features = false }
 ring = { version = "0.17", optional = true }
 aws-lc-rs = { version = "1.16", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
+quick-xml = { version = "0.36", features = ["serialize"] }
+chrono = { version = "0.4" , default-features = false, features = ["std", "clock", "now"] }
+hex = { version = "0.4" , default-features = false, features = ["std"] }
 
 [dev-dependencies]
-tokio = { version = "1.51", features = ["full"] }
-mockito = "1.6"
+tokio = { version = "1", features = ["full"] }
+mockito = { version = "1.6" }
 httpmock = { version = "0.8", features = ["https"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_urlencoded = { version = "0.7.1", default-features = false }
 ring = { version = "0.17", optional = true }
 aws-lc-rs = { version = "1.16", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
-quick-xml = { version = "0.36", features = ["serialize"] }
+quick-xml = { version = "0.39.2", features = ["serialize"] }
 chrono = { version = "0.4" , default-features = false, features = ["std", "clock", "now"] }
 hex = { version = "0.4" , default-features = false, features = ["std"] }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -25,6 +25,41 @@ pub fn sha1_digest(data: &[u8]) -> Vec<u8> {
     unimplemented!();
 }
 
+#[inline(always)]
+pub fn sha256_digest(data: &[u8]) -> Vec<u8> {
+    #[cfg(feature = "aws-lc-rs")]
+    return aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, data)
+        .as_ref()
+        .to_vec();
+
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    return ring::digest::digest(&ring::digest::SHA256, data)
+        .as_ref()
+        .to_vec();
+
+    #[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+    unimplemented!();
+}
+
+pub fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    #[cfg(feature = "aws-lc-rs")]
+    {
+        let key = aws_lc_rs::hmac::Key::new(aws_lc_rs::hmac::HMAC_SHA256, key);
+        let tag = aws_lc_rs::hmac::sign(&key, data);
+        tag.as_ref().to_vec()
+    }
+
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    {
+        let key = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, key);
+        let tag = ring::hmac::sign(&key, data);
+        tag.as_ref().to_vec()
+    }
+
+    #[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+    unimplemented!();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use hickory_client::proto::dnssec;
 use providers::{
     bunny::BunnyProvider, cloudflare::CloudflareProvider, desec::DesecProvider,
     digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, porkbun::PorkBunProvider,
-    spaceship::SpaceshipProvider, rfc2136::Rfc2136Provider,
+    rfc2136::Rfc2136Provider, route53::Route53Provider, spaceship::SpaceshipProvider,
 };
 use std::{
     borrow::Cow,
@@ -196,10 +196,7 @@ pub enum DnsUpdater {
     Porkbun(PorkBunProvider),
     Spaceship(SpaceshipProvider),
     DNSimple(DNSimpleProvider),
-    #[cfg(feature = "test_provider")]
-    Pebble(PebbleProvider),
-    #[cfg(feature = "test_provider")]
-    InMemory(InMemoryProvider),
+    Route53(Route53Provider),
 }
 
 pub trait IntoFqdn<'x> {

--- a/src/providers/bunny.rs
+++ b/src/providers/bunny.rs
@@ -9,7 +9,7 @@
  * except according to those terms.
  */
 
-use crate::{http::HttpClientBuilder, DnsRecord, DnsRecordType, Error, IntoFqdn};
+use crate::{DnsRecord, DnsRecordType, Error, IntoFqdn, http::HttpClientBuilder};
 use serde::{Deserialize, Serialize};
 use std::{
     net::{Ipv4Addr, Ipv6Addr},

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -24,6 +24,7 @@ pub mod pebble;
 pub mod porkbun;
 pub mod spaceship;
 pub mod rfc2136;
+pub mod route53;
 
 impl DnsRecord {
     pub fn priority(&self) -> Option<u16> {

--- a/src/providers/porkbun.rs
+++ b/src/providers/porkbun.rs
@@ -9,9 +9,7 @@
  * except according to those terms.
  */
 
-use crate::{
-    http::HttpClientBuilder, utils::strip_origin_from_name, DnsRecord, Error, IntoFqdn,
-};
+use crate::{DnsRecord, Error, IntoFqdn, http::HttpClientBuilder, utils::strip_origin_from_name};
 use serde::{Deserialize, Serialize};
 use std::{
     net::{Ipv4Addr, Ipv6Addr},

--- a/src/providers/route53.rs
+++ b/src/providers/route53.rs
@@ -1,0 +1,560 @@
+/*
+ * Copyright (c) 2024 Stalwart Labs Ltd.
+ *
+ * This file is part of the Stalwart DNS Update Client.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * in the LICENSE file at the top of the repository.
+ */
+
+use crate::crypto::{hmac_sha256, sha256_digest};
+use crate::{DnsRecord, DnsRecordType, IntoFqdn};
+
+use std::time::SystemTime;
+
+use quick_xml::de::from_str;
+use quick_xml::se::to_string;
+use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::{Client, Response};
+use serde::{Deserialize, Serialize};
+
+const ROUTE53_API_VERSION: &str = "2013-04-01";
+const ROUTE53_SERVICE: &str = "route53";
+const ROUTE53_HOST: &str = "route53.amazonaws.com";
+
+/// Route53 provider configuration
+#[derive(Debug, Clone)]
+pub struct Route53Config {
+    /// AWS access key ID (required)
+    pub access_key_id: String,
+    /// AWS secret access key (required)
+    pub secret_access_key: String,
+    /// AWS session token (optional, for temporary credentials)
+    pub session_token: Option<String>,
+    /// AWS region (optional, defaults to us-east-1)
+    pub region: Option<String>,
+    /// Hosted zone ID to use (optional, will resolve by name if not provided)
+    pub hosted_zone_id: Option<String>,
+    /// Whether to use private zones only (optional, defaults to false)
+    pub private_zone_only: Option<bool>,
+}
+
+/// Route53 DNS provider
+#[derive(Debug, Clone)]
+pub struct Route53Provider {
+    client: Client,
+    config: Route53Config,
+    region: String,
+}
+
+impl Route53Provider {
+    /// Create a new Route53 provider
+    pub fn new(config: Route53Config) -> Self {
+        let region = config
+            .region
+            .clone()
+            .unwrap_or_else(|| "us-east-1".to_string());
+
+        Self {
+            client: Client::new(),
+            config,
+            region,
+        }
+    }
+
+    /// Create a new DNS record
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        _origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_fqdn();
+        let hosted_zone_id = if let Some(zone_id) = &self.config.hosted_zone_id {
+            zone_id.clone()
+        } else {
+            self.resolve_hosted_zone(&name)
+                .await
+                .map_err(|e| crate::Error::Api(e.to_string()))?
+        };
+
+        let change_batch = ChangeBatch {
+            comment: Some(format!("Create record for {}", name)),
+            changes: vec![Change {
+                action: ChangeAction::Create,
+                resource_record_set: self
+                    .record_to_rrset(&name, &record, ttl)
+                    .map_err(|e| crate::Error::Api(format!("{}", e)))?,
+            }],
+        };
+
+        self.send_change_request(&hosted_zone_id, &change_batch)
+            .await
+            .map_err(|e| crate::Error::Api(e.to_string()))
+    }
+
+    /// Update an existing DNS record
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        _origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_fqdn();
+        let hosted_zone_id = if let Some(zone_id) = &self.config.hosted_zone_id {
+            zone_id.clone()
+        } else {
+            self.resolve_hosted_zone(&name)
+                .await
+                .map_err(|e| crate::Error::Api(e.to_string()))?
+        };
+
+        let change_batch = ChangeBatch {
+            comment: Some(format!("Update record for {}", name)),
+            changes: vec![Change {
+                action: ChangeAction::Upsert,
+                resource_record_set: self
+                    .record_to_rrset(&name, &record, ttl)
+                    .map_err(|e| crate::Error::Api(format!("{}", e)))?,
+            }],
+        };
+
+        self.send_change_request(&hosted_zone_id, &change_batch)
+            .await
+            .map_err(|e| crate::Error::Api(e.to_string()))
+    }
+
+    /// Delete an existing DNS record
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        _origin: impl IntoFqdn<'_>,
+        record_type: DnsRecordType,
+    ) -> crate::Result<()> {
+        let name = name.into_fqdn();
+        let hosted_zone_id = if let Some(zone_id) = &self.config.hosted_zone_id {
+            zone_id.clone()
+        } else {
+            self.resolve_hosted_zone(&name)
+                .await
+                .map_err(|e| crate::Error::Api(e.to_string()))?
+        };
+
+        // Find existing RRSet(s) for this name and type
+        let existing_rrsets = self
+            .list_resource_record_sets(&hosted_zone_id, &name, &record_type)
+            .await
+            .map_err(|e| crate::Error::Api(format!("{}", e)))?;
+
+        let type_str = self.record_type_to_string(&record_type);
+        let mut matching_rrsets: Vec<_> = existing_rrsets
+            .into_iter()
+            .filter(|r| r.name == name && r.type_ == type_str)
+            .collect();
+
+        match matching_rrsets.len() {
+            0 => {
+                // Record doesn't exist, consider this a success (idempotent delete)
+                Ok(())
+            }
+            1 => {
+                // Exactly one RRSet found, delete it
+                let rrset = matching_rrsets.pop().unwrap();
+                let change_batch = ChangeBatch {
+                    comment: Some(format!("Delete {} record for {}", record_type, name)),
+                    changes: vec![Change {
+                        action: ChangeAction::Delete,
+                        resource_record_set: rrset,
+                    }],
+                };
+                self.send_change_request(&hosted_zone_id, &change_batch)
+                    .await
+                    .map_err(|e| crate::Error::Api(format!("{}", e)))
+            }
+            _ => {
+                // Multiple RRSet found, this is ambiguous
+                Err(crate::Error::Api(format!(
+                    "Found {} RRSet(s) with name '{}' and type '{:?}'. Cannot delete ambiguous records.",
+                    matching_rrsets.len(),
+                    name,
+                    record_type
+                )))
+            }
+        }
+    }
+
+    /// Resolve hosted zone ID by name using longest suffix matching
+    async fn resolve_hosted_zone(
+        &self,
+        name: &str,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let zones = self.list_hosted_zones_by_name().await?;
+
+        let private_zone_only = self.config.private_zone_only.unwrap_or(false);
+
+        // Find zones that match the record name (longest suffix match)
+        let mut matching_zones = Vec::new();
+
+        for zone in zones {
+            if private_zone_only && !zone.config.private_zone {
+                continue;
+            }
+
+            // Check if the name ends with the zone name (with proper DNS name handling)
+            if name == zone.name || name.ends_with(&format!(".{}", zone.name)) {
+                matching_zones.push(zone);
+            }
+        }
+
+        // Sort by name length (longest first) and return the first match
+        matching_zones.sort_by(|a, b| b.name.len().cmp(&a.name.len()));
+
+        matching_zones
+            .into_iter()
+            .next()
+            .map(|zone| zone.id)
+            .ok_or_else(|| format!("No suitable hosted zone found for name: {}", name).into())
+    }
+
+    /// List hosted zones sorted by name
+    async fn list_hosted_zones_by_name(
+        &self,
+    ) -> Result<Vec<HostedZone>, Box<dyn std::error::Error + Send + Sync>> {
+        let url = format!(
+            "https://{}/{}/hostedzonebyname",
+            ROUTE53_HOST, ROUTE53_API_VERSION
+        );
+        let response = self.send_signed_request("GET", &url, None).await?;
+        let list_response: ListHostedZonesByNameResponse =
+            from_str(&response.text().await?).map_err(|e| format!("XML parsing error: {}", e))?;
+        Ok(list_response.hosted_zones)
+    }
+
+    /// List resource record sets for a specific name and type
+    async fn list_resource_record_sets(
+        &self,
+        hosted_zone_id: &str,
+        name: &str,
+        record_type: &DnsRecordType,
+    ) -> Result<Vec<ResourceRecordSet>, Box<dyn std::error::Error + Send + Sync>> {
+        let url = format!(
+            "https://{}/{}/hostedzone/{}/rrset?name={}&type={}",
+            ROUTE53_HOST,
+            ROUTE53_API_VERSION,
+            hosted_zone_id.trim_start_matches("/hostedzone/"),
+            name,
+            self.record_type_to_string(record_type)
+        );
+
+        let response = self.send_signed_request("GET", &url, None).await?;
+        let list_response: ListResourceRecordSetsResponse =
+            from_str(&response.text().await?).map_err(|e| format!("XML parsing error: {}", e))?;
+        Ok(list_response.resource_record_sets)
+    }
+
+    /// Send a change request to Route53
+    async fn send_change_request(
+        &self,
+        hosted_zone_id: &str,
+        change_batch: &ChangeBatch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let url = format!(
+            "https://{}/{}/hostedzone/{}/rrset",
+            ROUTE53_HOST,
+            ROUTE53_API_VERSION,
+            hosted_zone_id.trim_start_matches("/hostedzone/")
+        );
+
+        let payload =
+            to_string(change_batch).map_err(|e| format!("XML serialization error: {}", e))?;
+
+        self.send_signed_request("POST", &url, Some(payload))
+            .await?;
+        Ok(())
+    }
+
+    /// Send a signed HTTP request to Route53
+    async fn send_signed_request(
+        &self,
+        method: &str,
+        url: &str,
+        body: Option<String>,
+    ) -> Result<Response, Box<dyn std::error::Error + Send + Sync>> {
+        use chrono::{DateTime, Utc};
+        let datetime: DateTime<Utc> = SystemTime::now().into();
+        let amz_date = datetime.format("%Y%m%dT%H%M%SZ").to_string();
+        let date_stamp = datetime.format("%Y%m%d").to_string();
+
+        let mut headers = HeaderMap::new();
+        headers.insert("host", HeaderValue::from_str(ROUTE53_HOST)?);
+        headers.insert("x-amz-date", HeaderValue::from_str(&amz_date)?);
+
+        if let Some(session_token) = &self.config.session_token {
+            headers.insert(
+                "x-amz-security-token",
+                HeaderValue::from_str(session_token)?,
+            );
+        }
+
+        let body_str = body.as_deref().unwrap_or("");
+        let payload_hash = hex::encode(sha256_digest(body_str.as_bytes()));
+
+        // Create canonical request
+        let parsed_url = url.parse::<reqwest::Url>()?;
+        let canonical_uri = parsed_url.path();
+        let canonical_querystring = parsed_url.query().unwrap_or("");
+        let canonical_headers = format!("host:{}\nx-amz-date:{}\n", ROUTE53_HOST, amz_date);
+        let signed_headers = "host;x-amz-date";
+
+        let canonical_request = format!(
+            "{}\n{}\n{}\n{}\n{}\n{}",
+            method,
+            canonical_uri,
+            canonical_querystring,
+            canonical_headers,
+            signed_headers,
+            payload_hash
+        );
+
+        // Create string to sign
+        let algorithm = "AWS4-HMAC-SHA256";
+        let credential_scope = format!(
+            "{}/{}/{}/aws4_request",
+            date_stamp, self.region, ROUTE53_SERVICE
+        );
+        let string_to_sign = format!(
+            "{}\n{}\n{}\n{}",
+            algorithm,
+            amz_date,
+            credential_scope,
+            hex::encode(sha256_digest(canonical_request.as_bytes()))
+        );
+
+        // Calculate signature
+        let signing_key = self.get_signature_key(&date_stamp)?;
+        let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+
+        // Add authorization header
+        let authorization_header = format!(
+            "{} Credential={}/{}, SignedHeaders={}, Signature={}",
+            algorithm, self.config.access_key_id, credential_scope, signed_headers, signature
+        );
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&authorization_header)?,
+        );
+
+        // Send request
+        let mut request = self.client.request(method.parse()?, url);
+        request = request.headers(headers);
+
+        if let Some(body_content) = body {
+            request = request.body(body_content);
+        }
+
+        let response = request.send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("Route53 API error: {} - {}", status, body).into());
+        }
+
+        Ok(response)
+    }
+
+    /// Get AWS signature key
+    fn get_signature_key(
+        &self,
+        date_stamp: &str,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        let k_date = hmac_sha256(
+            format!("AWS4{}", self.config.secret_access_key).as_bytes(),
+            date_stamp.as_bytes(),
+        );
+        let k_region = hmac_sha256(&k_date, self.region.as_bytes());
+        let k_service = hmac_sha256(&k_region, ROUTE53_SERVICE.as_bytes());
+        let k_signing = hmac_sha256(&k_service, b"aws4_request");
+        Ok(k_signing)
+    }
+
+    /// Convert DNS record to Route53 ResourceRecordSet
+    fn record_to_rrset(
+        &self,
+        name: &str,
+        record: &DnsRecord,
+        ttl: u32,
+    ) -> Result<ResourceRecordSet, Box<dyn std::error::Error + Send + Sync>> {
+        let value = match record {
+            DnsRecord::A(addr) => addr.to_string(),
+            DnsRecord::AAAA(addr) => addr.to_string(),
+            DnsRecord::CNAME(name) => name.clone(),
+            DnsRecord::NS(name) => name.clone(),
+            DnsRecord::MX(mx) => mx.to_string(),
+            DnsRecord::TXT(text) => format!("\"{}\"", text.replace('\"', "\\\"")),
+            DnsRecord::SRV(srv) => srv.to_string(),
+            DnsRecord::TLSA(tlsa) => tlsa.to_string(),
+            DnsRecord::CAA(caa) => caa.to_string(),
+        };
+
+        let resource_records = vec![ResourceRecord { value }];
+
+        Ok(ResourceRecordSet {
+            name: name.to_string(),
+            type_: self.record_type_to_string(&record.as_type()),
+            ttl: ttl as i64,
+            resource_records,
+            set_identifier: None,
+            weight: None,
+            region: None,
+            geo_location: None,
+            health_check_id: None,
+            traffic_policy_instance_id: None,
+        })
+    }
+
+    /// Convert DNS record type to Route53 string
+    fn record_type_to_string(&self, record_type: &DnsRecordType) -> String {
+        match record_type {
+            DnsRecordType::A => "A".to_string(),
+            DnsRecordType::AAAA => "AAAA".to_string(),
+            DnsRecordType::CNAME => "CNAME".to_string(),
+            DnsRecordType::MX => "MX".to_string(),
+            DnsRecordType::TXT => "TXT".to_string(),
+            DnsRecordType::SRV => "SRV".to_string(),
+            DnsRecordType::NS => "NS".to_string(),
+            DnsRecordType::TLSA => "TLSA".to_string(),
+            DnsRecordType::CAA => "CAA".to_string(),
+        }
+    }
+}
+
+// XML structures for Route53 API
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ChangeBatch {
+    #[serde(rename = "@comment", skip_serializing_if = "Option::is_none")]
+    comment: Option<String>,
+    #[serde(rename = "Change")]
+    changes: Vec<Change>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Change {
+    #[serde(rename = "Action")]
+    action: ChangeAction,
+    #[serde(rename = "ResourceRecordSet")]
+    resource_record_set: ResourceRecordSet,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum ChangeAction {
+    Create,
+    Delete,
+    Upsert,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ResourceRecordSet {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Type")]
+    type_: String,
+    #[serde(rename = "TTL")]
+    ttl: i64,
+    #[serde(rename = "ResourceRecords")]
+    resource_records: Vec<ResourceRecord>,
+    #[serde(rename = "SetIdentifier", skip_serializing_if = "Option::is_none")]
+    set_identifier: Option<String>,
+    #[serde(rename = "Weight", skip_serializing_if = "Option::is_none")]
+    weight: Option<i64>,
+    #[serde(rename = "Region", skip_serializing_if = "Option::is_none")]
+    region: Option<String>,
+    #[serde(rename = "GeoLocation", skip_serializing_if = "Option::is_none")]
+    geo_location: Option<GeoLocation>,
+    #[serde(rename = "HealthCheckId", skip_serializing_if = "Option::is_none")]
+    health_check_id: Option<String>,
+    #[serde(
+        rename = "TrafficPolicyInstanceId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    traffic_policy_instance_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ResourceRecord {
+    #[serde(rename = "Value")]
+    value: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct GeoLocation {
+    #[serde(rename = "ContinentCode", skip_serializing_if = "Option::is_none")]
+    continent_code: Option<String>,
+    #[serde(rename = "CountryCode", skip_serializing_if = "Option::is_none")]
+    country_code: Option<String>,
+    #[serde(rename = "SubdivisionCode", skip_serializing_if = "Option::is_none")]
+    subdivision_code: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ListHostedZonesByNameResponse {
+    #[serde(rename = "HostedZones")]
+    hosted_zones: Vec<HostedZone>,
+    #[serde(rename = "IsTruncated")]
+    is_truncated: bool,
+    #[serde(rename = "NextRecordName", skip_serializing_if = "Option::is_none")]
+    next_record_name: Option<String>,
+    #[serde(rename = "NextRecordType", skip_serializing_if = "Option::is_none")]
+    next_record_type: Option<String>,
+    #[serde(rename = "MaxItems")]
+    max_items: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct HostedZone {
+    #[serde(rename = "Id")]
+    id: String,
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "CallerReference")]
+    caller_reference: String,
+    #[serde(rename = "Config")]
+    config: HostedZoneConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct HostedZoneConfig {
+    #[serde(rename = "PrivateZone")]
+    private_zone: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ListResourceRecordSetsResponse {
+    #[serde(rename = "ResourceRecordSets")]
+    resource_record_sets: Vec<ResourceRecordSet>,
+    #[serde(rename = "IsTruncated")]
+    is_truncated: bool,
+    #[serde(rename = "MaxItems")]
+    max_items: String,
+    #[serde(rename = "NextRecordName", skip_serializing_if = "Option::is_none")]
+    next_record_name: Option<String>,
+    #[serde(rename = "NextRecordType", skip_serializing_if = "Option::is_none")]
+    next_record_type: Option<String>,
+    #[serde(
+        rename = "NextRecordIdentifier",
+        skip_serializing_if = "Option::is_none"
+    )]
+    next_record_identifier: Option<String>,
+}

--- a/src/providers/route53.rs
+++ b/src/providers/route53.rs
@@ -1,18 +1,12 @@
 /*
- * Copyright (c) 2024 Stalwart Labs Ltd.
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
  *
- * This file is part of the Stalwart DNS Update Client.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- * in the LICENSE file at the top of the repository.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 use crate::crypto::{hmac_sha256, sha256_digest};

--- a/src/tests/bunny_test.rs
+++ b/src/tests/bunny_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{providers::bunny::BunnyProvider, DnsRecord, DnsUpdater};
+    use crate::{DnsRecord, DnsUpdater, providers::bunny::BunnyProvider};
     use std::time::Duration;
 
     #[tokio::test]
@@ -26,22 +26,12 @@ mod tests {
         let updater = DnsUpdater::new_bunny(api_key, Some(Duration::from_secs(30))).unwrap();
 
         let create_result = updater
-            .create(
-                &domain,
-                DnsRecord::A([1, 1, 1, 1].into()),
-                300,
-                &origin,
-            )
+            .create(&domain, DnsRecord::A([1, 1, 1, 1].into()), 300, &origin)
             .await;
         assert!(create_result.is_ok());
 
         let update_result = updater
-            .update(
-                &domain,
-                DnsRecord::A([8, 8, 8, 8].into()),
-                300,
-                &origin,
-            )
+            .update(&domain, DnsRecord::A([8, 8, 8, 8].into()), 300, &origin)
             .await;
         assert!(update_result.is_ok());
 

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests {
     use crate::providers::desec::DesecDnsRecordRepresentation;
-    use crate::{providers::desec::DesecProvider, DnsRecord, DnsRecordType, Error, MXRecord, SRVRecord};
+    use crate::{
+        DnsRecord, DnsRecordType, Error, MXRecord, SRVRecord, providers::desec::DesecProvider,
+    };
     use serde_json::json;
     use std::time::Duration;
 

--- a/src/tests/dnsimple_tests.rs
+++ b/src/tests/dnsimple_tests.rs
@@ -1,28 +1,17 @@
 #[cfg(test)]
 mod tests {
-    use crate::{
-        providers::dnsimple::DNSimpleProvider,
-        DnsRecord, DnsRecordType, DnsUpdater,
-    };
+    use crate::{DnsRecord, DnsRecordType, DnsUpdater, providers::dnsimple::DNSimpleProvider};
     use serde_json::json;
     use std::time::Duration;
 
     fn setup_provider(endpoint: &str) -> DNSimpleProvider {
-        DNSimpleProvider::new(
-            "test_bearer_token",
-            "1010",
-            Some(Duration::from_secs(1)),
-        )
-        .with_endpoint(endpoint)
+        DNSimpleProvider::new("test_bearer_token", "1010", Some(Duration::from_secs(1)))
+            .with_endpoint(endpoint)
     }
 
     #[test]
     fn dns_updater_creation() {
-        let updater = DnsUpdater::new_dnsimple(
-            "test_token",
-            "1010",
-            Some(Duration::from_secs(30)),
-        );
+        let updater = DnsUpdater::new_dnsimple("test_token", "1010", Some(Duration::from_secs(30)));
 
         assert!(updater.is_ok());
         assert!(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,4 +16,6 @@ pub mod dnsimple_tests;
 pub mod lib_tests;
 pub mod ovh_tests;
 pub mod porkbun_tests;
+#[cfg(test)]
+pub mod route53_tests;
 pub mod spaceship_tests;

--- a/src/tests/ovh_tests.rs
+++ b/src/tests/ovh_tests.rs
@@ -12,9 +12,9 @@
 #[cfg(test)]
 mod tests {
     use crate::{
+        CAARecord, DnsRecord, DnsRecordType, DnsUpdater, Error, MXRecord, SRVRecord, TLSARecord,
+        TlsaCertUsage, TlsaMatching, TlsaSelector,
         providers::ovh::{OvhEndpoint, OvhProvider, OvhRecordFormat},
-        CAARecord, DnsRecord, DnsRecordType, DnsUpdater, Error, MXRecord, SRVRecord,
-        TLSARecord, TlsaCertUsage, TlsaMatching, TlsaSelector,
     };
     use serde_json::json;
     use std::time::Duration;
@@ -440,9 +440,7 @@ mod tests {
 
         assert!(update_result.is_ok());
 
-        let deletion_result = updater
-            .delete(&domain, &origin, DnsRecordType::A)
-            .await;
+        let deletion_result = updater.delete(&domain, &origin, DnsRecordType::A).await;
 
         assert!(deletion_result.is_ok());
 
@@ -454,9 +452,9 @@ mod tests {
                     selector: TlsaSelector::Spki,
                     matching: TlsaMatching::Sha256,
                     cert_data: vec![
-                        0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4,
-                        0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b,
-                        0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+                        0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8,
+                        0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+                        0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
                     ],
                 }),
                 3600,
@@ -466,9 +464,7 @@ mod tests {
 
         assert!(tlsa_result.is_ok());
 
-        let tlsa_deletion_result = updater
-            .delete(&domain, &origin, DnsRecordType::TLSA)
-            .await;
+        let tlsa_deletion_result = updater.delete(&domain, &origin, DnsRecordType::TLSA).await;
 
         assert!(tlsa_deletion_result.is_ok());
 
@@ -487,9 +483,7 @@ mod tests {
 
         assert!(caa_result.is_ok());
 
-        let caa_deletion_result = updater
-            .delete(&domain, &origin, DnsRecordType::CAA)
-            .await;
+        let caa_deletion_result = updater.delete(&domain, &origin, DnsRecordType::CAA).await;
 
         assert!(caa_deletion_result.is_ok());
     }

--- a/src/tests/porkbun_tests.rs
+++ b/src/tests/porkbun_tests.rs
@@ -11,8 +11,8 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        providers::porkbun::{PorkBunProvider, RecordData},
         DnsRecord, DnsRecordType, DnsUpdater, MXRecord, SRVRecord,
+        providers::porkbun::{PorkBunProvider, RecordData},
     };
     use serde_json::json;
     use std::{

--- a/src/tests/route53_tests.rs
+++ b/src/tests/route53_tests.rs
@@ -1,18 +1,12 @@
 /*
- * Copyright (c) 2024 Stalwart Labs Ltd.
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
  *
- * This file is part of the Stalwart DNS Update Client.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- * in the LICENSE file at the top of the repository.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 use crate::DnsUpdater;

--- a/src/tests/route53_tests.rs
+++ b/src/tests/route53_tests.rs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Stalwart Labs Ltd.
+ *
+ * This file is part of the Stalwart DNS Update Client.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * in the LICENSE file at the top of the repository.
+ */
+
+use crate::DnsUpdater;
+use crate::providers::route53::{Route53Config, Route53Provider};
+
+#[tokio::test]
+async fn test_route53_provider_creation() {
+    let config = Route53Config {
+        access_key_id: "test_access_key".to_string(),
+        secret_access_key: "test_secret_key".to_string(),
+        session_token: None,
+        region: Some("us-east-1".to_string()),
+        hosted_zone_id: Some("test_zone_id".to_string()),
+        private_zone_only: Some(false),
+    };
+
+    // Test that provider creation succeeds
+    let _provider = Route53Provider::new(config);
+}
+
+#[tokio::test]
+async fn test_route53_updater_creation() {
+    let config = Route53Config {
+        access_key_id: "test_access_key".to_string(),
+        secret_access_key: "test_secret_key".to_string(),
+        session_token: None,
+        region: Some("us-west-2".to_string()),
+        hosted_zone_id: None,
+        private_zone_only: Some(true),
+    };
+
+    // Test that DnsUpdater creation succeeds
+    let updater = DnsUpdater::new_route53(config).unwrap();
+    match updater {
+        DnsUpdater::Route53(_) => {
+            // Successfully created Route53 updater
+            assert!(true);
+        }
+        _ => panic!("Expected Route53 provider"),
+    }
+}
+
+#[tokio::test]
+async fn test_route53_config_defaults() {
+    let config = Route53Config {
+        access_key_id: "test_access_key".to_string(),
+        secret_access_key: "test_secret_key".to_string(),
+        session_token: None,
+        region: None, // Should default to us-east-1
+        hosted_zone_id: None,
+        private_zone_only: None, // Should default to false
+    };
+
+    // Test that provider creation with defaults succeeds
+    let _provider = Route53Provider::new(config);
+}
+
+#[tokio::test]
+async fn test_route53_config_with_session_token() {
+    let config = Route53Config {
+        access_key_id: "test_access_key".to_string(),
+        secret_access_key: "test_secret_key".to_string(),
+        session_token: Some("test_session_token".to_string()),
+        region: Some("eu-west-1".to_string()),
+        hosted_zone_id: Some("Z1234567890".to_string()),
+        private_zone_only: Some(true),
+    };
+
+    // Test that provider creation with session token succeeds
+    let _provider = Route53Provider::new(config);
+}
+
+#[tokio::test]
+async fn test_route53_config_minimal() {
+    let config = Route53Config {
+        access_key_id: "test_access_key".to_string(),
+        secret_access_key: "test_secret_key".to_string(),
+        session_token: None,
+        region: None,
+        hosted_zone_id: None,
+        private_zone_only: None,
+    };
+
+    // Test that minimal config works
+    let updater = DnsUpdater::new_route53(config).unwrap();
+    match updater {
+        DnsUpdater::Route53(_) => {
+            // Successfully created Route53 updater with minimal config
+            assert!(true);
+        }
+        _ => panic!("Expected Route53 provider"),
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -36,8 +36,9 @@ use crate::{
         digitalocean::DigitalOceanProvider,
         dnsimple::DNSimpleProvider,
         porkbun::PorkBunProvider,
-        spaceship::SpaceshipProvider,
         rfc2136::{DnsAddress, Rfc2136Provider},
+        route53::Route53Provider,
+        spaceship::SpaceshipProvider,
     },
 };
 use std::time::Duration;
@@ -159,6 +160,9 @@ impl DnsUpdater {
         Ok(DnsUpdater::DNSimple(DNSimpleProvider::new(
             auth_token, account_id, timeout,
         )))
+    }
+    pub fn new_route53(config: crate::providers::route53::Route53Config) -> crate::Result<Self> {
+        Ok(DnsUpdater::Route53(Route53Provider::new(config)))
     }
 
     /// Create a new DNS updater using the Pebble Challenge Test Server.

--- a/src/update.rs
+++ b/src/update.rs
@@ -161,6 +161,8 @@ impl DnsUpdater {
             auth_token, account_id, timeout,
         )))
     }
+
+    /// Create a new DNS updater using the Route53 API.
     pub fn new_route53(config: crate::providers::route53::Route53Config) -> crate::Result<Self> {
         Ok(DnsUpdater::Route53(Route53Provider::new(config)))
     }
@@ -186,16 +188,17 @@ impl DnsUpdater {
         origin: impl IntoFqdn<'_>,
     ) -> crate::Result<()> {
         match self {
-            DnsUpdater::Rfc2136(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Bunny(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Cloudflare(provider) => provider.create(name, record, ttl, origin).await,
-            DnsUpdater::DigitalOcean(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Desec(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::DigitalOcean(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::DNSimple(provider) => provider.create(name, record, ttl, origin).await,
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.create(name, record, ttl, origin).await,
-            DnsUpdater::Bunny(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Porkbun(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Rfc2136(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Route53(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Spaceship(provider) => provider.create(name, record, ttl, origin).await,
-            DnsUpdater::DNSimple(provider) => provider.create(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::Pebble(provider) => provider.create(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
@@ -212,16 +215,17 @@ impl DnsUpdater {
         origin: impl IntoFqdn<'_>,
     ) -> crate::Result<()> {
         match self {
-            DnsUpdater::Rfc2136(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Bunny(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Cloudflare(provider) => provider.update(name, record, ttl, origin).await,
-            DnsUpdater::DigitalOcean(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Desec(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::DigitalOcean(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::DNSimple(provider) => provider.update(name, record, ttl, origin).await,
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.update(name, record, ttl, origin).await,
-            DnsUpdater::Bunny(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Porkbun(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Rfc2136(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Route53(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Spaceship(provider) => provider.update(name, record, ttl, origin).await,
-            DnsUpdater::DNSimple(provider) => provider.update(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::Pebble(provider) => provider.update(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
@@ -237,16 +241,17 @@ impl DnsUpdater {
         record: DnsRecordType,
     ) -> crate::Result<()> {
         match self {
-            DnsUpdater::Rfc2136(provider) => provider.delete(name, origin).await,
+            DnsUpdater::Bunny(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Cloudflare(provider) => provider.delete(name, origin).await,
-            DnsUpdater::DigitalOcean(provider) => provider.delete(name, origin).await,
             DnsUpdater::Desec(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::DigitalOcean(provider) => provider.delete(name, origin).await,
+            DnsUpdater::DNSimple(provider) => provider.delete(name, origin, record).await,
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.delete(name, origin, record).await,
-            DnsUpdater::Bunny(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Porkbun(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::Rfc2136(provider) => provider.delete(name, origin).await,
+            DnsUpdater::Route53(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Spaceship(provider) => provider.delete(name, origin, record).await,
-            DnsUpdater::DNSimple(provider) => provider.delete(name, origin, record).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::Pebble(provider) => provider.delete(name, origin, record).await,
             #[cfg(feature = "test_provider")]


### PR DESCRIPTION
Hello,

This is a rewrite of the Route53 provider #23 to use the bare minimum. It might be possible to reduce this further. I tried to find a balance and figured that using hex, time, and XML in libraries could be useful to future providers.

This is not a complete implementation for Route53; it currently doesn't support assume role or some of the more advanced authentication methods that Route53 allows. I kept this to a minimum to keep the review size reasonable. Once this is merged ill move on to these if required.

### Core Functionality
- Create, update, and delete DNS records in Route53
- SigV4 authentication with SHA-256 and HMAC-SHA256
- Support for A, AAAA, CNAME, MX, TXT, SRV, NS, TLSA, and CAA records
- Automatic zone discovery with longest suffix matching
- Region selection, hosted zone ID, and private zone filtering

### Security & Authentication
- Uses explicit AWS access keys (no environment variable lookup)
- Compatible with temporary AWS credentials
- Complete AWS SigV4 implementation with canonical request signing
- Compatible with both `ring` and `aws-lc-rs` features

### Usability
- Uses configured hosted zone ID if provided
- Searches zones by name using longest suffix matching
- Supports private/public zone filtering
- Returns an error if no suitable zone is found
- Errors if multiple RRSet found with same name/type (due to routing policies)

