### PR TITLE
desec.io: Fixes + Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+dns-update 0.2.3
+================================
+- Fix deSEC provider to include trailing dots on MX, SRV, CNAME and NS record values, as required by the API.
+
 dns-update 0.2.2
 ================================
 - Fix `CAA` record updates for Cloudflare provider.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dns-update"
 description = "Dynamic DNS update (RFC 2136 and cloud) library for Rust"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = [ "Stalwart Labs <hello@stalw.art>"]
 license = "Apache-2.0 OR MIT"

--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -161,6 +161,14 @@ impl DesecProvider {
     }
 }
 
+fn ensure_fqdn(name: String) -> String {
+    if name.ends_with('.') {
+        name
+    } else {
+        format!("{name}.")
+    }
+}
+
 /// Converts a DNS record into a representation that can be sent to the desec API.
 impl From<DnsRecord> for DesecDnsRecordRepresentation {
     fn from(record: DnsRecord) -> Self {
@@ -175,15 +183,15 @@ impl From<DnsRecord> for DesecDnsRecordRepresentation {
             },
             DnsRecord::CNAME(content) => DesecDnsRecordRepresentation {
                 record_type: "CNAME".to_string(),
-                content,
+                content: ensure_fqdn(content),
             },
             DnsRecord::NS(content) => DesecDnsRecordRepresentation {
                 record_type: "NS".to_string(),
-                content,
+                content: ensure_fqdn(content),
             },
             DnsRecord::MX(mx) => DesecDnsRecordRepresentation {
                 record_type: "MX".to_string(),
-                content: mx.to_string(),
+                content: format!("{} {}", mx.priority, ensure_fqdn(mx.exchange)),
             },
             DnsRecord::TXT(content) => DesecDnsRecordRepresentation {
                 record_type: "TXT".to_string(),
@@ -191,7 +199,13 @@ impl From<DnsRecord> for DesecDnsRecordRepresentation {
             },
             DnsRecord::SRV(srv) => DesecDnsRecordRepresentation {
                 record_type: "SRV".to_string(),
-                content: srv.to_string(),
+                content: format!(
+                    "{} {} {} {}",
+                    srv.priority,
+                    srv.weight,
+                    srv.port,
+                    ensure_fqdn(srv.target)
+                ),
             },
             DnsRecord::TLSA(tlsa) => DesecDnsRecordRepresentation {
                 record_type: "TLSA".to_string(),

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -2,7 +2,8 @@
 mod tests {
     use crate::providers::desec::DesecDnsRecordRepresentation;
     use crate::{
-        DnsRecord, DnsRecordType, Error, MXRecord, SRVRecord, providers::desec::DesecProvider,
+        CAARecord, DnsRecord, DnsRecordType, Error, MXRecord, SRVRecord, TLSARecord, TlsaCertUsage,
+        TlsaMatching, TlsaSelector, providers::desec::DesecProvider,
     };
     use serde_json::json;
     use std::time::Duration;
@@ -200,6 +201,248 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_tlsa_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_request = json!({
+            "subname": "_443._tcp.test",
+            "type": "TLSA",
+            "ttl": 3600,
+            "records": ["3 1 1 e3b0c442"],
+        });
+
+        let mock = server
+            .mock("POST", "/domains/example.com/rrsets/")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .match_header("authorization", "Token test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(expected_request))
+            .with_body(
+                r#"{
+                    "created": "2025-07-25T19:18:37.286381Z",
+                    "domain": "example.com",
+                    "subname": "_443._tcp.test",
+                    "name": "_443._tcp.test.example.com.",
+                    "records": ["3 1 1 e3b0c442"],
+                    "ttl": 3600,
+                    "type": "TLSA",
+                    "touched": "2025-07-25T19:18:37.292390Z"
+                }"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .create(
+                "_443._tcp.test.example.com",
+                DnsRecord::TLSA(TLSARecord {
+                    cert_usage: TlsaCertUsage::DaneEe,
+                    selector: TlsaSelector::Spki,
+                    matching: TlsaMatching::Sha256,
+                    cert_data: vec![0xe3, 0xb0, 0xc4, 0x42],
+                }),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_update_tlsa_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_request = json!({
+            "subname": "_443._tcp.test",
+            "type": "TLSA",
+            "ttl": 3600,
+            "records": ["2 0 2 abcdef01"],
+        });
+
+        let mock = server
+            .mock("PUT", "/domains/example.com/rrsets/_443._tcp.test/TLSA/")
+            .with_status(200)
+            .match_body(mockito::Matcher::Json(expected_request))
+            .match_header("authorization", "Token test_token")
+            .with_body(
+                r#"{
+                    "created": "2025-07-25T19:18:37.286381Z",
+                    "domain": "example.com",
+                    "subname": "_443._tcp.test",
+                    "name": "_443._tcp.test.example.com.",
+                    "records": ["2 0 2 abcdef01"],
+                    "ttl": 3600,
+                    "type": "TLSA",
+                    "touched": "2025-07-25T19:18:37.292390Z"
+                }"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .update(
+                "_443._tcp.test",
+                DnsRecord::TLSA(TLSARecord {
+                    cert_usage: TlsaCertUsage::DaneTa,
+                    selector: TlsaSelector::Full,
+                    matching: TlsaMatching::Sha512,
+                    cert_data: vec![0xab, 0xcd, 0xef, 0x01],
+                }),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_create_caa_issue_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_request = json!({
+            "subname": "test",
+            "type": "CAA",
+            "ttl": 3600,
+            "records": ["0 issue \"letsencrypt.org\""],
+        });
+
+        let mock = server
+            .mock("POST", "/domains/example.com/rrsets/")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .match_header("authorization", "Token test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(expected_request))
+            .with_body(
+                r#"{
+                    "created": "2025-07-25T19:18:37.286381Z",
+                    "domain": "example.com",
+                    "subname": "test",
+                    "name": "test.example.com.",
+                    "records": ["0 issue \"letsencrypt.org\""],
+                    "ttl": 3600,
+                    "type": "CAA",
+                    "touched": "2025-07-25T19:18:37.292390Z"
+                }"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::CAA(CAARecord::Issue {
+                    issuer_critical: false,
+                    name: Some("letsencrypt.org".to_string()),
+                    options: vec![],
+                }),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_update_caa_issuewild_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_request = json!({
+            "subname": "test",
+            "type": "CAA",
+            "ttl": 3600,
+            "records": ["128 issuewild \"letsencrypt.org\""],
+        });
+
+        let mock = server
+            .mock("PUT", "/domains/example.com/rrsets/test/CAA/")
+            .with_status(200)
+            .match_body(mockito::Matcher::Json(expected_request))
+            .match_header("authorization", "Token test_token")
+            .with_body(
+                r#"{
+                    "created": "2025-07-25T19:18:37.286381Z",
+                    "domain": "example.com",
+                    "subname": "test",
+                    "name": "test.example.com.",
+                    "records": ["128 issuewild \"letsencrypt.org\""],
+                    "ttl": 3600,
+                    "type": "CAA",
+                    "touched": "2025-07-25T19:18:37.292390Z"
+                }"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .update(
+                "test",
+                DnsRecord::CAA(CAARecord::IssueWild {
+                    issuer_critical: true,
+                    name: Some("letsencrypt.org".to_string()),
+                    options: vec![],
+                }),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_create_caa_iodef_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let expected_request = json!({
+            "subname": "test",
+            "type": "CAA",
+            "ttl": 3600,
+            "records": ["0 iodef \"mailto:admin@example.com\""],
+        });
+
+        let mock = server
+            .mock("POST", "/domains/example.com/rrsets/")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .match_header("authorization", "Token test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(expected_request))
+            .with_body(
+                r#"{
+                    "created": "2025-07-25T19:18:37.286381Z",
+                    "domain": "example.com",
+                    "subname": "test",
+                    "name": "test.example.com.",
+                    "records": ["0 iodef \"mailto:admin@example.com\""],
+                    "ttl": 3600,
+                    "type": "CAA",
+                    "touched": "2025-07-25T19:18:37.292390Z"
+                }"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::CAA(CAARecord::Iodef {
+                    issuer_critical: false,
+                    url: "mailto:admin@example.com".to_string(),
+                }),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
     #[ignore = "Requires desec API Token and domain configuration"]
     async fn integration_test() {
         let token = ""; // <-- Fill in your deSEC API token here
@@ -273,7 +516,7 @@ mod tests {
             priority: 10,
         });
         let desec_record: DesecDnsRecordRepresentation = record.into();
-        assert_eq!(desec_record.content, "10 mail.example.com");
+        assert_eq!(desec_record.content, "10 mail.example.com.");
         assert_eq!(desec_record.record_type, "MX");
 
         let record = DnsRecord::SRV(SRVRecord {
@@ -283,7 +526,43 @@ mod tests {
             port: 443,
         });
         let desec_record: DesecDnsRecordRepresentation = record.into();
-        assert_eq!(desec_record.content, "10 20 443 sip.example.com");
+        assert_eq!(desec_record.content, "10 20 443 sip.example.com.");
         assert_eq!(desec_record.record_type, "SRV");
+
+        let record = DnsRecord::TLSA(TLSARecord {
+            cert_usage: TlsaCertUsage::DaneEe,
+            selector: TlsaSelector::Spki,
+            matching: TlsaMatching::Sha256,
+            cert_data: vec![0xde, 0xad, 0xbe, 0xef],
+        });
+        let desec_record: DesecDnsRecordRepresentation = record.into();
+        assert_eq!(desec_record.content, "3 1 1 deadbeef");
+        assert_eq!(desec_record.record_type, "TLSA");
+
+        let record = DnsRecord::CAA(CAARecord::Issue {
+            issuer_critical: false,
+            name: Some("letsencrypt.org".to_string()),
+            options: vec![],
+        });
+        let desec_record: DesecDnsRecordRepresentation = record.into();
+        assert_eq!(desec_record.content, "0 issue \"letsencrypt.org\"");
+        assert_eq!(desec_record.record_type, "CAA");
+
+        let record = DnsRecord::CAA(CAARecord::IssueWild {
+            issuer_critical: true,
+            name: Some("letsencrypt.org".to_string()),
+            options: vec![],
+        });
+        let desec_record: DesecDnsRecordRepresentation = record.into();
+        assert_eq!(desec_record.content, "128 issuewild \"letsencrypt.org\"");
+        assert_eq!(desec_record.record_type, "CAA");
+
+        let record = DnsRecord::CAA(CAARecord::Iodef {
+            issuer_critical: false,
+            url: "mailto:admin@example.com".to_string(),
+        });
+        let desec_record: DesecDnsRecordRepresentation = record.into();
+        assert_eq!(desec_record.content, "0 iodef \"mailto:admin@example.com\"");
+        assert_eq!(desec_record.record_type, "CAA");
     }
 }

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -463,35 +463,55 @@ mod tests {
         );
 
         let provider = DesecProvider::new(token, Some(Duration::from_secs(30)));
+        let cname_sub = format!("cname-test.{origin}");
+        let srv_sub = format!("_sip._tcp.{origin}");
+        let tlsa_sub = format!("_443._tcp.{origin}");
 
-        // check creation
-        let creation_result = provider
-            .create(
-                domain,
-                DnsRecord::A("1.1.1.1".parse().unwrap()),
-                3600,
-                origin,
-            )
-            .await;
+        // --- Create & update all record types ---
 
-        assert!(creation_result.is_ok());
+        // A record
+        assert!(provider.create(domain, DnsRecord::A("1.1.1.1".parse().unwrap()), 3600, origin).await.is_ok());
+        assert!(provider.update(domain, DnsRecord::A("2.2.2.2".parse().unwrap()), 3600, origin).await.is_ok());
 
-        // check modification
-        let update_result = provider
-            .update(
-                domain,
-                DnsRecord::A("2.2.2.2".parse().unwrap()),
-                3600,
-                origin,
-            )
-            .await;
+        // AAAA record
+        assert!(provider.create(domain, DnsRecord::AAAA("2001:db8::1".parse().unwrap()), 3600, origin).await.is_ok());
+        assert!(provider.update(domain, DnsRecord::AAAA("2001:db8::2".parse().unwrap()), 3600, origin).await.is_ok());
 
-        assert!(update_result.is_ok());
+        // TXT record
+        assert!(provider.create(domain, DnsRecord::TXT("v=spf1 -all".to_string()), 3600, origin).await.is_ok());
+        assert!(provider.update(domain, DnsRecord::TXT("v=spf1 ~all".to_string()), 3600, origin).await.is_ok());
 
-        // check deletion
-        let deletion_result = provider.delete(domain, origin, DnsRecordType::A).await;
+        // MX record
+        assert!(provider.create(domain, DnsRecord::MX(MXRecord { exchange: format!("mail.{origin}"), priority: 10 }), 3600, origin).await.is_ok());
+        assert!(provider.update(domain, DnsRecord::MX(MXRecord { exchange: format!("mail2.{origin}"), priority: 20 }), 3600, origin).await.is_ok());
 
-        assert!(deletion_result.is_ok());
+        // CNAME record (dedicated subdomain — cannot coexist with other record types)
+        assert!(provider.create(&cname_sub, DnsRecord::CNAME(format!("target.{origin}")), 3600, origin).await.is_ok());
+        assert!(provider.update(&cname_sub, DnsRecord::CNAME(format!("target2.{origin}")), 3600, origin).await.is_ok());
+
+        // SRV record
+        assert!(provider.create(&srv_sub, DnsRecord::SRV(SRVRecord { priority: 10, weight: 20, port: 5060, target: format!("sip.{origin}") }), 3600, origin).await.is_ok());
+        assert!(provider.update(&srv_sub, DnsRecord::SRV(SRVRecord { priority: 20, weight: 10, port: 5060, target: format!("sip2.{origin}") }), 3600, origin).await.is_ok());
+
+        // TLSA record
+        assert!(provider.create(&tlsa_sub, DnsRecord::TLSA(TLSARecord { cert_usage: TlsaCertUsage::DaneEe, selector: TlsaSelector::Spki, matching: TlsaMatching::Sha256, cert_data: vec![0xe3, 0xb0, 0xc4, 0x42] }), 3600, origin).await.is_ok());
+        assert!(provider.update(&tlsa_sub, DnsRecord::TLSA(TLSARecord { cert_usage: TlsaCertUsage::DaneEe, selector: TlsaSelector::Spki, matching: TlsaMatching::Sha256, cert_data: vec![0xab, 0xcd, 0xef, 0x01] }), 3600, origin).await.is_ok());
+
+        // CAA record
+        assert!(provider.create(domain, DnsRecord::CAA(CAARecord::Issue { issuer_critical: false, name: Some("letsencrypt.org".to_string()), options: vec![] }), 3600, origin).await.is_ok());
+        assert!(provider.update(domain, DnsRecord::CAA(CAARecord::Issue { issuer_critical: false, name: Some("sectigo.com".to_string()), options: vec![] }), 3600, origin).await.is_ok());
+
+        // Set DESEC_NO_CLEANUP=1 to skip deletion (e.g. to inspect records in the web UI).
+        if std::env::var("DESEC_NO_CLEANUP").unwrap_or_default().is_empty() {
+            assert!(provider.delete(domain, origin, DnsRecordType::A).await.is_ok());
+            assert!(provider.delete(domain, origin, DnsRecordType::AAAA).await.is_ok());
+            assert!(provider.delete(domain, origin, DnsRecordType::TXT).await.is_ok());
+            assert!(provider.delete(domain, origin, DnsRecordType::MX).await.is_ok());
+            assert!(provider.delete(&cname_sub, origin, DnsRecordType::CNAME).await.is_ok());
+            assert!(provider.delete(&srv_sub, origin, DnsRecordType::SRV).await.is_ok());
+            assert!(provider.delete(&tlsa_sub, origin, DnsRecordType::TLSA).await.is_ok());
+            assert!(provider.delete(domain, origin, DnsRecordType::CAA).await.is_ok());
+        }
     }
 
     #[test]

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -63,7 +63,7 @@ mod tests {
             "subname": "test",
             "type": "MX",
             "ttl": 3600,
-            "records": ["10 mail.example.com"],
+            "records": ["10 mail.example.com."],
         });
 
         let mock = server
@@ -79,7 +79,7 @@ mod tests {
                     "domain": "example.com",
                     "subname": "test",
                     "name": "test.example.com.",
-                    "records": ["10 mail.example.com"],
+                    "records": ["10 mail.example.com."],
                     "ttl": 3600,
                     "type": "MX",
                     "touched": "2025-07-25T19:18:37.292390Z"
@@ -147,6 +147,7 @@ mod tests {
             "ttl": 3600,
             "records": ["2001:db8::1"],
         });
+
 
         let mock = server
             .mock("PUT", "/domains/example.com/rrsets/test/AAAA/")


### PR DESCRIPTION
Hi,

as requested in #15, I checked my desec.io provider for `CAA` and `TLSA` support. The good news is, these records work. I still made two changes:
1. I added a new a function to make sure that, entries with FQDN values (`SRV`, `CNAME`, `NS`, `MX`) receive a trailing dot as required by desec.io
2. Added unit tests for `CAA` and `TLSA` entries, as well as integration tests for all entry types for verification.

Here is the result of the integration tests:

<img width="1560" height="858" alt="image" src="https://github.com/user-attachments/assets/3f2696bf-7e5c-48f1-b4bb-70389ee5ac0e" />
