### PR TITLE
Support Gandi LiveDNS API.

### DIFF
--- a/examples/gandi.rs
+++ b/examples/gandi.rs
@@ -1,0 +1,34 @@
+use dns_update::{DnsRecord, DnsRecordType, DnsUpdater};
+use std::env;
+use std::time::Duration;
+
+#[tokio::main]
+pub async fn main() -> Result<(), std::env::VarError> {
+    let token = env::var("GANDIV5_PERSONAL_ACCESS_TOKEN")
+        .expect("Envvar GANDIV5_PERSONAL_ACCESS_TOKEN should be set with valid token");
+    let domain =
+        env::var("GANDIV5_DOMAIN").expect("Envvar GANDIV5_DOMAIN should be set with DNS domain");
+
+    let client = DnsUpdater::new_gandi(token, Some(Duration::from_secs(120))).unwrap();
+
+    // Create a new TXT record
+
+    let client_result = client
+        .create(
+            format!("dns-update-example.{}", domain),
+            DnsRecord::TXT("\"test dns-update record\"".to_string()),
+            3600,
+            &domain,
+        )
+        .await;
+
+    println!("client create result={:?}", client_result);
+
+    let client_del_result = client
+        .delete("dns-update-example", &domain, DnsRecordType::TXT)
+        .await;
+
+    println!("client del result={:?}", client_del_result);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use providers::{
     bunny::BunnyProvider, cloudflare::CloudflareProvider, desec::DesecProvider,
     digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, porkbun::PorkBunProvider,
     rfc2136::Rfc2136Provider, route53::Route53Provider, spaceship::SpaceshipProvider,
+    gandi::GandiProvider,
 };
 use std::{
     borrow::Cow,
@@ -202,6 +203,7 @@ pub enum DnsUpdater {
     #[cfg(feature = "test_provider")]
     InMemory(InMemoryProvider),
     Route53(Route53Provider),
+    Gandi(GandiProvider),
 }
 
 pub trait IntoFqdn<'x> {

--- a/src/providers/gandi.rs
+++ b/src/providers/gandi.rs
@@ -1,0 +1,190 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use crate::{DnsRecord, Error, IntoFqdn, utils::strip_origin_from_name};
+use reqwest::Method;
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct GandiProvider {
+    token: String,
+    pub(crate) endpoint: String,
+    timeout: Duration,
+}
+
+#[derive(Serialize, Debug)]
+pub struct UpdateDnsRecordParams {
+    #[serde(rename = "rrset_values")]
+    pub values: Vec<String>,
+    #[serde(rename = "rrset_ttl")]
+    pub ttl: u32,
+}
+
+#[derive(Debug)]
+pub struct GandiRecordFormat {
+    pub kind: String,
+    pub value: String,
+}
+
+const GANDIV5_LIVEDNS_URL: &str = "https://api.gandi.net/v5/livedns";
+
+impl From<&DnsRecord> for GandiRecordFormat {
+    fn from(record: &DnsRecord) -> Self {
+        match record {
+            DnsRecord::A(content) => GandiRecordFormat {
+                kind: "A".to_string(),
+                value: content.to_string(),
+            },
+            DnsRecord::AAAA(content) => GandiRecordFormat {
+                kind: "AAAA".to_string(),
+                value: content.to_string(),
+            },
+            DnsRecord::CNAME(content) => GandiRecordFormat {
+                kind: "CNAME".to_string(),
+                value: content.clone(),
+            },
+            DnsRecord::NS(content) => GandiRecordFormat {
+                kind: "NS".to_string(),
+                value: content.clone(),
+            },
+            DnsRecord::MX(mx) => GandiRecordFormat {
+                kind: "MX".to_string(),
+                value: mx.to_string(),
+            },
+            DnsRecord::TXT(content) => GandiRecordFormat {
+                kind: "TXT".to_string(),
+                value: content.clone(),
+            },
+            DnsRecord::SRV(srv) => GandiRecordFormat {
+                kind: "SRV".to_string(),
+                value: srv.to_string(),
+            },
+            DnsRecord::TLSA(tlsa) => GandiRecordFormat {
+                kind: "TLSA".to_string(),
+                value: tlsa.to_string(),
+            },
+            DnsRecord::CAA(caa) => GandiRecordFormat {
+                kind: "CAA".to_string(),
+                value: caa.to_string(),
+            },
+        }
+    }
+}
+
+impl GandiProvider {
+    pub(crate) fn new(
+        token: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> crate::Result<Self> {
+        Ok(Self {
+            token: token.as_ref().to_string(),
+            endpoint: GANDIV5_LIVEDNS_URL.to_string(),
+            timeout: timeout.unwrap_or(Duration::from_secs(30)),
+        })
+    }
+
+    async fn send_record_request(
+        &self,
+        zone: &str,
+        name: &str,
+        kind: &str,
+        method: Method,
+        body: Option<&str>,
+    ) -> crate::Result<()> {
+        let client = reqwest::Client::builder()
+            .timeout(self.timeout)
+            .build()
+            .map_err(|e| Error::Client(format!("Failed to create HTTP client: {}", e)))?;
+
+        let url = format!("{}/domains/{}/records/{}/{}", self.endpoint, zone, name, kind);
+
+        let mut request = client
+            .request(method, url)
+            .header("Accept", "application/json")
+            .header("Authorization", format!("Bearer {0}", self.token))
+            .header("Content-Type", "application/json");
+
+        if let Some(body) = body {
+            request = request.body(body.to_string());
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| Error::Api(format!("Failed to send request: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(Error::Api(format!(
+                "Failed to update record: HTTP {} - {}",
+                status, error_text
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let domain = origin.into_name();
+        let subdomain = strip_origin_from_name(&name.into_name(), &domain, None);
+
+        let gandi_record: GandiRecordFormat = (&record).into();
+        let (kind, values) = (gandi_record.kind, vec![gandi_record.value]);
+
+        let params = UpdateDnsRecordParams { values, ttl };
+        let body = serde_json::to_string(&params)
+            .map_err(|e| Error::Serialize(format!("Failed to serialize record: {}", e)))?;
+
+        self.send_record_request(&domain, &subdomain, &kind, Method::POST, Some(&body)).await
+    }
+
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let domain = origin.into_name();
+        let subdomain = strip_origin_from_name(&name.into_name(), &domain, None);
+
+        let gandi_record: GandiRecordFormat = (&record).into();
+        let (kind, values) = (gandi_record.kind, vec![gandi_record.value]);
+
+        let params = UpdateDnsRecordParams { values, ttl };
+        let body = serde_json::to_string(&params)
+            .map_err(|e| Error::Serialize(format!("Failed to serialize record: {}", e)))?;
+
+        self.send_record_request(&domain, &subdomain, &kind, Method::PUT, Some(&body)).await
+    }
+
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        origin: impl IntoFqdn<'_>,
+        record_type: crate::DnsRecordType,
+    ) -> crate::Result<()> {
+        let domain = origin.into_name();
+        let subdomain = strip_origin_from_name(&name.into_name(), &domain, None);
+        self.send_record_request(&domain, &subdomain, record_type.as_str(), Method::DELETE, None).await
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -16,6 +16,7 @@ pub mod cloudflare;
 pub mod desec;
 pub mod digitalocean;
 pub mod dnsimple;
+pub mod gandi;
 pub mod google_cloud_dns;
 #[cfg(feature = "test_provider")]
 pub mod in_memory;

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -149,7 +149,6 @@ mod tests {
             "records": ["2001:db8::1"],
         });
 
-
         let mock = server
             .mock("PUT", "/domains/example.com/rrsets/test/AAAA/")
             .with_status(200)

--- a/src/tests/gandi_tests.rs
+++ b/src/tests/gandi_tests.rs
@@ -1,0 +1,316 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        CAARecord, DnsRecord, DnsRecordType, DnsUpdater, Error, MXRecord, SRVRecord, TLSARecord,
+        TlsaCertUsage, TlsaMatching, TlsaSelector,
+        providers::gandi::{GandiProvider, GandiRecordFormat},
+    };
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn setup_provider() -> GandiProvider {
+        GandiProvider::new(
+            "test_token",
+            Some(Duration::from_secs(1)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_gandi_provider_creation() {
+        let provider = GandiProvider::new(
+            "test_token",
+            Some(Duration::from_secs(30)),
+        );
+
+        assert!(provider.is_ok());
+    }
+
+    #[test]
+    fn test_dns_updater_gandi_creation() {
+        let updater = DnsUpdater::new_gandi(
+            "test_token",
+            Some(Duration::from_secs(30)),
+        );
+
+        assert!(updater.is_ok());
+
+        match updater.unwrap() {
+            DnsUpdater::Gandi(_) => (),
+            _ => panic!("Expected Gandi provider"),
+        }
+    }
+
+    #[test]
+    fn test_gandi_record_format_from_dns_record() {
+        let record = DnsRecord::A("1.1.1.1".parse().unwrap());
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "A");
+        assert_eq!(gandi_record.value, "1.1.1.1");
+
+        let record = DnsRecord::AAAA("2001:db8::1".parse().unwrap());
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "AAAA");
+        assert_eq!(gandi_record.value, "2001:db8::1");
+
+        let record = DnsRecord::CNAME("alias.example.com".to_string());
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "CNAME");
+        assert_eq!(gandi_record.value, "alias.example.com");
+
+        let record = DnsRecord::MX(MXRecord {
+            exchange: "mail.example.com".to_string(),
+            priority: 10,
+        });
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "MX");
+        assert_eq!(gandi_record.value, "10 mail.example.com");
+
+        let record = DnsRecord::TXT("\"v=spf1 include:_spf.example.com ~all\"".to_string());
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "TXT");
+        assert_eq!(gandi_record.value, "\"v=spf1 include:_spf.example.com ~all\"");
+
+        let record = DnsRecord::TXT("v=spf1 include:_spf.example.com ~all".to_string());
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "TXT");
+        assert_eq!(gandi_record.value, "v=spf1 include:_spf.example.com ~all");
+
+        let record = DnsRecord::SRV(SRVRecord {
+            target: "sip.example.com".to_string(),
+            priority: 10,
+            weight: 20,
+            port: 443,
+        });
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "SRV");
+        assert_eq!(gandi_record.value, "10 20 443 sip.example.com");
+
+        let record = DnsRecord::NS("ns1.example.com".to_string());
+        let gandi_record: GandiRecordFormat = (&record).into();
+        assert_eq!(gandi_record.kind, "NS");
+        assert_eq!(gandi_record.value, "ns1.example.com");
+    }
+
+    #[tokio::test]
+    async fn test_create_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let create_mock = server
+            .mock("POST", "/domains/example.com/records/test/A")
+            .with_status(200)
+            .match_header("authorization", "Bearer test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "rrset_values": ["1.1.1.1"],
+                "rrset_ttl": 3600
+            })))
+            .with_body(r#"{"message": "SUCCESS"}"#)
+            .create();
+
+        let mut provider = setup_provider();
+        provider.endpoint = server.url();
+
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::A("1.1.1.1".parse().unwrap()),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        create_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_update_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let update_mock = server
+            .mock("PUT", "/domains/example.com/records/test/A")
+            .with_status(200)
+            .match_header("authorization", "Bearer test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "rrset_values": ["2.2.2.2"],
+                "rrset_ttl": 3600
+            })))
+            .with_body(r#"{"message": "SUCCESS"}"#)
+            .create();
+
+        let mut provider = setup_provider();
+        provider.endpoint = server.url();
+
+        let result = provider
+            .update(
+                "test.example.com",
+                DnsRecord::A("2.2.2.2".parse().unwrap()),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        dbg!(&result);
+        assert!(result.is_ok());
+        update_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_delete_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let delete_mock = server
+            .mock("DELETE", "/domains/example.com/records/test/TXT")
+            .with_status(200)
+            .match_header("authorization", "Bearer test_token")
+            .match_header("content-type", "application/json")
+            .with_body(r#"{"message": "SUCCESS"}"#)
+            .create();
+
+        let mut provider = setup_provider();
+        provider.endpoint = server.url();
+
+        let result = provider
+            .delete("test.example.com", "example.com", DnsRecordType::TXT)
+            .await;
+
+        assert!(result.is_ok());
+        delete_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_create_record_unauthorized() {
+        let mut server = mockito::Server::new_async().await;
+
+        let zone_mock = server
+            .mock("POST", "/domains/example.com/records/test/A")
+            .with_status(401)
+            .match_header("authorization", "Bearer test_token")
+            .with_body(r#"{"message": "Invalid credentials"}"#)
+            .create();
+
+        let mut provider = setup_provider();
+        provider.endpoint = server.url();
+
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::A("1.1.1.1".parse().unwrap()),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::Api(_))));
+        zone_mock.assert();
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Gandi API credentials and domain configuration"]
+    async fn integration_test() {
+        let token = std::env::var("GANDIV5_PERSONAL_ACCESS_TOKEN").unwrap_or_default();
+        let origin = std::env::var("GANDIV5_ORIGIN").unwrap_or_default();
+        let domain = std::env::var("GANDIV5_DOMAIN").unwrap_or_default();
+
+        assert!(
+            !token.is_empty(),
+            "Please configure your Gandi application key in the integration test"
+        );
+        assert!(
+            !origin.is_empty(),
+            "Please configure your domain in the integration test"
+        );
+        assert!(
+            !domain.is_empty(),
+            "Please configure your test subdomain in the integration test"
+        );
+
+        let updater = DnsUpdater::new_gandi(
+            token,
+            Some(Duration::from_secs(30)),
+        )
+        .unwrap();
+
+        let creation_result = updater
+            .create(
+                &domain,
+                DnsRecord::A("1.1.1.1".parse().unwrap()),
+                3600,
+                &origin,
+            )
+            .await;
+
+        assert!(creation_result.is_ok());
+
+        let update_result = updater
+            .update(
+                &domain,
+                DnsRecord::A("2.2.2.2".parse().unwrap()),
+                3600,
+                &origin,
+            )
+            .await;
+
+        assert!(update_result.is_ok());
+
+        let deletion_result = updater.delete(&domain, &origin, DnsRecordType::A).await;
+
+        assert!(deletion_result.is_ok());
+
+        let tlsa_result = updater
+            .create(
+                &domain,
+                DnsRecord::TLSA(TLSARecord {
+                    cert_usage: TlsaCertUsage::DaneEe,
+                    selector: TlsaSelector::Spki,
+                    matching: TlsaMatching::Sha256,
+                    cert_data: vec![
+                        0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8,
+                        0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+                        0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+                    ],
+                }),
+                3600,
+                &origin,
+            )
+            .await;
+
+        assert!(tlsa_result.is_ok());
+
+        let tlsa_deletion_result = updater.delete(&domain, &origin, DnsRecordType::TLSA).await;
+
+        assert!(tlsa_deletion_result.is_ok());
+
+        let caa_result = updater
+            .create(
+                &domain,
+                DnsRecord::CAA(CAARecord::Issue {
+                    issuer_critical: false,
+                    name: Some("letsencrypt.org".to_string()),
+                    options: vec![],
+                }),
+                3600,
+                &origin,
+            )
+            .await;
+
+        assert!(caa_result.is_ok());
+
+        let caa_deletion_result = updater.delete(&domain, &origin, DnsRecordType::CAA).await;
+
+        assert!(caa_deletion_result.is_ok());
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,6 +12,7 @@
 pub mod bunny_test;
 pub mod desec_tests;
 pub mod dnsimple_tests;
+pub mod gandi_tests;
 pub mod google_cloud_dns_tests;
 #[cfg(test)]
 pub mod lib_tests;

--- a/src/update.rs
+++ b/src/update.rs
@@ -39,6 +39,7 @@ use crate::{
         rfc2136::{DnsAddress, Rfc2136Provider},
         route53::Route53Provider,
         spaceship::SpaceshipProvider,
+        gandi::GandiProvider,
     },
 };
 use std::time::Duration;
@@ -200,6 +201,17 @@ impl DnsUpdater {
         DnsUpdater::InMemory(InMemoryProvider::new(records))
     }
 
+    /// Create a new DNS updater using the Gandi LiveDNS API.
+    pub fn new_gandi(
+        token: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> crate::Result<Self> {
+        Ok(DnsUpdater::Gandi(GandiProvider::new(
+            token,
+            timeout,
+        )?))
+    }
+
     /// Create a new DNS record.
     pub async fn create(
         &self,
@@ -220,6 +232,7 @@ impl DnsUpdater {
             DnsUpdater::Rfc2136(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Route53(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Spaceship(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Gandi(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::GoogleCloudDns(provider) => {
                 provider.create(name, record, ttl, origin).await
             }
@@ -250,6 +263,7 @@ impl DnsUpdater {
             DnsUpdater::Rfc2136(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Route53(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Spaceship(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Gandi(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::GoogleCloudDns(provider) => {
                 provider.update(name, record, ttl, origin).await
             }
@@ -279,6 +293,7 @@ impl DnsUpdater {
             DnsUpdater::Rfc2136(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Route53(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Spaceship(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::Gandi(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::GoogleCloudDns(provider) => provider.delete(name, origin, record).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::Pebble(provider) => provider.delete(name, origin, record).await,


### PR DESCRIPTION
Using the same environment variable as https://go-acme.github.io/lego/dns/gandiv5/ for the personal access token (in the example app and integration tests).