### PR TITLE
Add Infomaniak Provider

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use providers::{in_memory::InMemoryProvider, pebble::PebbleProvider};
 pub use hickory_client::proto::dnssec;
 use providers::{
     bunny::BunnyProvider, cloudflare::CloudflareProvider, desec::DesecProvider,
-    digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, porkbun::PorkBunProvider,
+    digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, infomaniak::InfomaniakProvider, porkbun::PorkBunProvider,
     rfc2136::Rfc2136Provider, route53::Route53Provider, spaceship::SpaceshipProvider,
 };
 use std::{
@@ -193,6 +193,7 @@ pub enum DnsUpdater {
     #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
     Ovh(OvhProvider),
     Bunny(BunnyProvider),
+    Infomaniak(InfomaniakProvider),
     Porkbun(PorkBunProvider),
     Spaceship(SpaceshipProvider),
     DNSimple(DNSimpleProvider),

--- a/src/providers/infomaniak.rs
+++ b/src/providers/infomaniak.rs
@@ -1,0 +1,277 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use crate::{
+    DnsRecord, DnsRecordType, Error, IntoFqdn, http::HttpClientBuilder,
+    utils::strip_origin_from_name,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct InfomaniakProvider {
+    client: HttpClientBuilder,
+}
+
+/// Infomaniak DNS provider implementation.
+/// API documentation: <https://developer.infomaniak.com/docs/api>
+///
+/// Getting your API key: <https://manager.infomaniak.com/v3/ng/accounts/token/list>
+/// API key permissions: `dns:read` and `dns:write` for the relevant domain(s)
+///
+/// Implemented using:
+/// - [Store](https://developer.infomaniak.com/docs/api/post/2/zones/%7Bzone%7D/records)
+/// - [Update](https://developer.infomaniak.com/docs/api/put/2/zones/%7Bzone%7D/records/%7Brecord%7D)
+/// - [Delete](https://developer.infomaniak.com/docs/api/delete/2/zones/%7Bzone%7D/records/%7Brecord%7D)
+///
+/// and a helper function to retrieve existing records for update/delete operations:
+/// - [List](https://developer.infomaniak.com/docs/api/get/2/zones/%7Bzone%7D/records)
+impl InfomaniakProvider {
+    pub(crate) fn new(api_key: impl AsRef<str>, timeout: Option<Duration>) -> crate::Result<Self> {
+        Ok(Self {
+            client: HttpClientBuilder::default()
+                .with_header("Authorization", format!("Bearer {}", api_key.as_ref()))
+                .with_timeout(timeout),
+        })
+    }
+
+    // ---
+    // Library functions
+
+    /// Create/Store a new DNS record.
+    /// [Store](https://developer.infomaniak.com/docs/api/post/2/zones/%7Bzone%7D/records)
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name().to_string();
+        let origin = origin.into_name().to_string();
+        let source = strip_origin_from_name(&name, &origin, Some("."));
+        let record_type = record.as_type().as_str().to_string();
+        let target = record.to_infomaniak_target();
+
+        let body = CreateRecordBody {
+            source,
+            target,
+            ttl,
+            r#type: record_type,
+        };
+
+        self.client
+            .post(format!(
+                "https://api.infomaniak.com/2/zones/{origin}/records"
+            ))
+            .with_body(&body)?
+            .send::<InfomaniakApiResponse<serde_json::Value>>()
+            .await?
+            .into_result()
+            .map(|_| ())
+    }
+
+    /// Update an existing DNS record.
+    /// Infomaniak's API requires the record ID for update operation.
+    /// This function first lists all records for the zone and matches
+    /// the record by name and type to get the required ID.
+    /// If multiple records with the same name and type exist, only the first one will be updated.
+    /// [Update](https://developer.infomaniak.com/docs/api/put/2/zones/%7Bzone%7D/records/%7Brecord%7D)
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let name = name.into_name().to_string();
+        let origin = origin.into_name().to_string();
+        let source = strip_origin_from_name(&name, &origin, Some("."));
+
+        let records = self.get_zone_records(origin.as_str()).await?;
+        let infomaniak_record = records
+            .iter()
+            .find(|r| r.source == source && r.record_type == record.as_type().as_str())
+            .ok_or(Error::NotFound)?;
+
+        let target = record.to_infomaniak_target();
+        let body = UpdateRecordBody { target, ttl };
+
+        self.client
+            .put(format!(
+                "https://api.infomaniak.com/2/zones/{origin}/records/{}",
+                infomaniak_record.id
+            ))
+            .with_body(&body)?
+            .send_with_retry::<InfomaniakApiResponse<serde_json::Value>>(3)
+            .await?
+            .into_result()
+            .map(|_| ())
+    }
+
+    /// Delete an existing DNS record.
+    /// Infomaniak's API requires the record ID for delete operation.
+    /// This function first lists all records for the zone and matches
+    /// the record by name and type to get the required ID.
+    /// If multiple records with the same name and type exist, only the first one will be deleted.
+    /// [Delete](https://developer.infomaniak.com/docs/api/delete/2/zones/%7Bzone%7D/records/%7Brecord%7D)
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        origin: impl IntoFqdn<'_>,
+        record: DnsRecordType,
+    ) -> crate::Result<()> {
+        let name = name.into_name().to_string();
+        let origin = origin.into_name().to_string();
+        let source = strip_origin_from_name(&name, &origin, Some("."));
+
+        let records = self.get_zone_records(origin.as_str()).await?;
+        let record_id = records
+            .iter()
+            .find(|r| r.source == source && r.record_type == record.as_str())
+            .map(|r| r.id)
+            .ok_or(Error::NotFound)?;
+
+        self.client
+            .delete(format!(
+                "https://api.infomaniak.com/2/zones/{origin}/records/{record_id}"
+            ))
+            .send::<InfomaniakApiResponse<serde_json::Value>>()
+            .await?
+            .into_result()
+            .map(|_| ())
+    }
+
+    // ---
+    // Utility functions
+
+    /// [List](https://developer.infomaniak.com/docs/api/get/2/zones/%7Bzone%7D/records)
+    async fn get_zone_records(
+        &self,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<Vec<InfomaniakDnsRecord>> {
+        let origin = origin.into_name();
+        let domain = origin.as_ref();
+
+        self.client
+            .get(format!(
+                "https://api.infomaniak.com/2/zones/{domain}/records"
+            ))
+            .send_with_retry::<InfomaniakRecordsList<InfomaniakDnsRecord>>(3)
+            .await?
+            .into_result()
+    }
+}
+
+// -----------
+// Local Structs, Traits and Implementations
+
+trait InfomaniakFormat {
+    fn to_infomaniak_target(&self) -> String;
+}
+
+impl InfomaniakFormat for DnsRecord {
+    fn to_infomaniak_target(&self) -> String {
+        match self {
+            DnsRecord::A(ip) => ip.to_string(),
+            DnsRecord::AAAA(ip) => ip.to_string(),
+            DnsRecord::CNAME(name) | DnsRecord::NS(name) => name.clone(),
+            DnsRecord::MX(mx) => mx.to_string(),
+            DnsRecord::TXT(text) => text.to_string(),
+            DnsRecord::SRV(srv) => srv.to_string(),
+            DnsRecord::TLSA(tlsa) => tlsa.to_string(),
+            DnsRecord::CAA(caa) => caa.to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct InfomaniakApiResponse<T> {
+    result: String,
+    data: T,
+}
+
+impl<T> InfomaniakApiResponse<T> {
+    fn into_result(self) -> crate::Result<T> {
+        if self.result == "success" {
+            Ok(self.data)
+        } else {
+            Err(Error::Api(format!(
+                "Infomaniak API returned result={}",
+                self.result
+            )))
+        }
+    }
+}
+
+// -----------
+// API Requests
+
+#[derive(Serialize, Clone, Debug)]
+struct CreateRecordBody {
+    source: String,
+    target: String,
+    ttl: u32,
+    #[serde(rename = "type")]
+    r#type: String,
+}
+
+#[derive(Serialize, Clone, Debug)]
+struct UpdateRecordBody {
+    target: String,
+    ttl: u32,
+}
+
+// -----------
+// API Responses
+
+#[derive(Deserialize, Clone, Debug)]
+struct InfomaniakRecordsList<InfomaniakDnsRecord> {
+    result: String,
+    data: Vec<InfomaniakDnsRecord>,
+    #[expect(dead_code)]
+    total: Option<u32>,
+    #[expect(dead_code)]
+    page: Option<u32>,
+    #[expect(dead_code)]
+    pages: Option<u32>,
+    #[expect(dead_code)]
+    items_per_page: Option<u32>,
+}
+
+impl<T> InfomaniakRecordsList<T> {
+    fn into_result(self) -> crate::Result<Vec<T>> {
+        if self.result == "success" {
+            Ok(self.data)
+        } else {
+            Err(Error::Api(format!(
+                "Infomaniak API returned result={}",
+                self.result
+            )))
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+struct InfomaniakDnsRecord {
+    id: u32,
+    source: String,
+    source_idn: Option<String>,
+    #[serde(rename = "type")]
+    record_type: String,
+    ttl: u32,
+    target: String,
+    updated_at: u64,
+    dyndns_id: Option<u32>,
+    delegated_zone: Option<serde_json::Value>,
+    description: Option<serde_json::Value>,
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -19,6 +19,7 @@ pub mod dnsimple;
 pub mod google_cloud_dns;
 #[cfg(feature = "test_provider")]
 pub mod in_memory;
+pub mod infomaniak;
 pub mod ovh;
 #[cfg(feature = "test_provider")]
 pub mod pebble;

--- a/src/tests/infomaniak_tests.rs
+++ b/src/tests/infomaniak_tests.rs
@@ -1,0 +1,332 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        CAARecord, DnsRecord, DnsRecordType, DnsUpdater, MXRecord, SRVRecord, TLSARecord,
+        TlsaCertUsage, TlsaMatching, TlsaSelector, providers::infomaniak::InfomaniakProvider,
+    };
+    use std::time::Duration;
+
+    // toggles for manual inspection of records
+    const CREATE_RECORDS: bool = true;
+    const UPDATE_RECORDS: bool = true;
+    const DELETE_RECORDS: bool = true;
+
+    fn test_records() -> Vec<(DnsRecord, DnsRecord, DnsRecordType)> {
+        vec![
+            (
+                DnsRecord::A([1, 1, 1, 1].into()),
+                DnsRecord::A([8, 8, 8, 8].into()),
+                DnsRecordType::A,
+            ),
+            (
+                DnsRecord::AAAA("2606:4700:4700::1111".parse().unwrap()),
+                DnsRecord::AAAA("2001:4860:4860::8888".parse().unwrap()),
+                DnsRecordType::AAAA,
+            ),
+            (
+                DnsRecord::CNAME("create.example.com".to_string()),
+                DnsRecord::CNAME("update.example.com".to_string()),
+                DnsRecordType::CNAME,
+            ),
+            (
+                DnsRecord::NS("ns1.example.com".to_string()),
+                DnsRecord::NS("ns2.example.com".to_string()),
+                DnsRecordType::NS,
+            ),
+            (
+                DnsRecord::MX(MXRecord {
+                    priority: 10,
+                    exchange: "mail1.example.com".to_string(),
+                }),
+                DnsRecord::MX(MXRecord {
+                    priority: 20,
+                    exchange: "mail2.example.com".to_string(),
+                }),
+                DnsRecordType::MX,
+            ),
+            (
+                DnsRecord::TXT("hello-infomaniak-create".to_string()),
+                DnsRecord::TXT("hello-infomaniak-update".to_string()),
+                DnsRecordType::TXT,
+            ),
+            (
+                DnsRecord::SRV(SRVRecord {
+                    priority: 10,
+                    weight: 5,
+                    port: 443,
+                    target: "sip1.example.com".to_string(),
+                }),
+                DnsRecord::SRV(SRVRecord {
+                    priority: 20,
+                    weight: 10,
+                    port: 8443,
+                    target: "sip2.example.com".to_string(),
+                }),
+                DnsRecordType::SRV,
+            ),
+            (
+                DnsRecord::TLSA(TLSARecord {
+                    cert_usage: TlsaCertUsage::DaneEe,
+                    selector: TlsaSelector::Spki,
+                    matching: TlsaMatching::Sha256,
+                    cert_data: (0xA0..0xC0).collect(),
+                }),
+                DnsRecord::TLSA(TLSARecord {
+                    cert_usage: TlsaCertUsage::DaneEe,
+                    selector: TlsaSelector::Spki,
+                    matching: TlsaMatching::Sha256,
+                    cert_data: (0xC0..0xE0).collect(),
+                }),
+                DnsRecordType::TLSA,
+            ),
+            (
+                DnsRecord::CAA(CAARecord::Issue {
+                    issuer_critical: false,
+                    name: Some("letsencrypt.org".to_string()),
+                    options: vec![],
+                }),
+                DnsRecord::CAA(CAARecord::Issue {
+                    issuer_critical: false,
+                    name: Some("letsdecrypt.org".to_string()),
+                    options: vec![],
+                }),
+                DnsRecordType::CAA,
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Infomaniak API keys and domain configuration"]
+    async fn integration_test_all_record_types() {
+        let api_key = std::env::var("INFOMANIAK_API_KEY").unwrap_or_default();
+        let domain = std::env::var("INFOMANIAK_DOMAIN").unwrap_or_default();
+        let origin = std::env::var("INFOMANIAK_ORIGIN").unwrap_or_default();
+
+        assert!(!api_key.is_empty(), "Please configure INFOMANIAK_API_KEY");
+        assert!(!domain.is_empty(), "Please configure INFOMANIAK_DOMAIN");
+        assert!(!origin.is_empty(), "Please configure INFOMANIAK_ORIGIN");
+
+        let updater = DnsUpdater::new_infomaniak(api_key, Some(Duration::from_secs(30))).unwrap();
+
+        for (create_record, update_record, record_type) in test_records() {
+            let test_domain = match record_type {
+                DnsRecordType::SRV => srv_domain(&domain, &record_type),
+                _ => format!("{}-{}", record_type.as_str().to_ascii_lowercase(), domain),
+            };
+
+            if CREATE_RECORDS {
+                let create_result = updater
+                    .create(&test_domain, create_record.clone(), 300, &origin)
+                    .await;
+
+                assert!(
+                    create_result.is_ok(),
+                    "Failed to create {:?}: {:?}",
+                    record_type,
+                    create_result
+                );
+            }
+
+            if UPDATE_RECORDS {
+                let update_result = updater
+                    .update(&test_domain, update_record, 300, &origin)
+                    .await;
+
+                assert!(
+                    update_result.is_ok(),
+                    "Failed to update {:?}: {:?}",
+                    record_type,
+                    update_result
+                );
+            }
+
+            if DELETE_RECORDS {
+                let delete_result = updater.delete(&test_domain, &origin, record_type).await;
+
+                assert!(
+                    delete_result.is_ok(),
+                    "Failed to delete {:?}: {:?}",
+                    record_type,
+                    delete_result
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Infomaniak API keys and domain configuration"]
+    async fn integration_test_duplicate_records() {
+        let api_key = std::env::var("INFOMANIAK_API_KEY").unwrap_or_default();
+        let domain = std::env::var("INFOMANIAK_DOMAIN").unwrap_or_default();
+        let origin = std::env::var("INFOMANIAK_ORIGIN").unwrap_or_default();
+
+        assert!(!api_key.is_empty(), "Please configure INFOMANIAK_API_KEY");
+        assert!(!domain.is_empty(), "Please configure INFOMANIAK_DOMAIN");
+        assert!(!origin.is_empty(), "Please configure INFOMANIAK_ORIGIN");
+
+        let updater = DnsUpdater::new_infomaniak(api_key, Some(Duration::from_secs(30))).unwrap();
+
+        if CREATE_RECORDS {
+            let create_result = updater
+                .create(
+                    &domain,
+                    DnsRecord::TXT("infomaniak-test-1".to_string()),
+                    300,
+                    &origin,
+                )
+                .await;
+            assert!(
+                create_result.is_ok(),
+                "Failed to create first record: {:?}",
+                create_result
+            );
+
+            let create_result = updater
+                .create(
+                    &domain,
+                    DnsRecord::TXT("infomaniak-test-2".to_string()),
+                    300,
+                    &origin,
+                )
+                .await;
+            assert!(
+                create_result.is_ok(),
+                "Failed to create second record: {:?}",
+                create_result,
+            );
+        }
+
+        if UPDATE_RECORDS {
+            let update_result = updater
+                .update(
+                    &domain,
+                    DnsRecord::TXT("infomaniak-test-3".to_string()),
+                    300,
+                    &origin,
+                )
+                .await;
+            assert!(
+                update_result.is_ok(),
+                "Failed to update duplicate record: {:?}",
+                update_result,
+            );
+        }
+        if DELETE_RECORDS {
+            let delete_result = updater.delete(&domain, &origin, DnsRecordType::TXT).await;
+            assert!(
+                delete_result.is_ok(),
+                "Failed to delete first record: {:?}",
+                delete_result,
+            );
+            let delete_result = updater.delete(&domain, &origin, DnsRecordType::TXT).await;
+            assert!(
+                delete_result.is_ok(),
+                "Failed to delete second record: {:?}",
+                delete_result,
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Infomaniak API keys and domain configuration"]
+    async fn integration_test_create_zone_level_record() {
+        let api_key = std::env::var("INFOMANIAK_API_KEY").unwrap_or_default();
+        let origin = std::env::var("INFOMANIAK_ORIGIN").unwrap_or_default();
+
+        assert!(!api_key.is_empty(), "Please configure INFOMANIAK_API_KEY");
+        assert!(!origin.is_empty(), "Please configure INFOMANIAK_ORIGIN");
+
+        let updater = DnsUpdater::new_infomaniak(api_key, Some(Duration::from_secs(30))).unwrap();
+
+        // let origin = "";
+
+        if CREATE_RECORDS {
+            let create_result = updater
+                .create(
+                    &origin,
+                    DnsRecord::TLSA(TLSARecord {
+                        cert_usage: TlsaCertUsage::DaneEe,
+                        selector: TlsaSelector::Spki,
+                        matching: TlsaMatching::Sha256,
+                        cert_data: (0xA0..0xC0).collect(),
+                    }),
+                    300,
+                    &origin,
+                )
+                .await;
+
+            assert!(
+                create_result.is_ok(),
+                "Failed to create zone-level TLSA record: {:?}",
+                create_result
+            );
+        }
+
+        if UPDATE_RECORDS {
+            let update_result = updater
+                .update(
+                    &origin,
+                    DnsRecord::TLSA(TLSARecord {
+                        cert_usage: TlsaCertUsage::DaneEe,
+                        selector: TlsaSelector::Spki,
+                        matching: TlsaMatching::Sha256,
+                        cert_data: (0xC0..0xE0).collect(),
+                    }),
+                    300,
+                    &origin,
+                )
+                .await;
+
+            assert!(
+                update_result.is_ok(),
+                "Failed to update zone-level TLSA record: {:?}",
+                update_result
+            );
+        }
+
+        if DELETE_RECORDS {
+            let delete_result = updater.delete(&origin, &origin, DnsRecordType::TLSA).await;
+
+            assert!(
+                delete_result.is_ok(),
+                "Failed to delete zone-level TLSA record: {:?}",
+                delete_result
+            );
+        }
+    }
+
+    #[test]
+    fn provider_creation() {
+        let provider =
+            InfomaniakProvider::new("infomaniak-mock-api-key", Some(Duration::from_secs(1)));
+
+        assert!(provider.is_ok());
+    }
+
+    #[test]
+    fn dns_updater_creation() {
+        let updater =
+            DnsUpdater::new_infomaniak("infomaniak-mock-api-key", Some(Duration::from_secs(30)));
+
+        assert!(
+            matches!(updater, Ok(DnsUpdater::Infomaniak(..))),
+            "Expected Infomaniak updater to provide an Infomaniak provider"
+        );
+    }
+
+    fn srv_domain(base: &str, record_type: &DnsRecordType) -> String {
+        let (label, rest) = base.split_once('.').unwrap_or((base, ""));
+
+        let prefix = format!(
+            "{}-{}._tcp",
+            record_type.as_str().to_ascii_lowercase(),
+            label
+        );
+
+        if rest.is_empty() {
+            prefix
+        } else {
+            format!("{prefix}.{rest}")
+        }
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,6 +13,7 @@ pub mod bunny_test;
 pub mod desec_tests;
 pub mod dnsimple_tests;
 pub mod google_cloud_dns_tests;
+pub mod infomaniak_tests;
 #[cfg(test)]
 pub mod lib_tests;
 pub mod ovh_tests;

--- a/src/update.rs
+++ b/src/update.rs
@@ -35,6 +35,7 @@ use crate::{
         desec::DesecProvider,
         digitalocean::DigitalOceanProvider,
         dnsimple::DNSimpleProvider,
+        infomaniak::InfomaniakProvider,
         porkbun::PorkBunProvider,
         rfc2136::{DnsAddress, Rfc2136Provider},
         route53::Route53Provider,
@@ -139,6 +140,11 @@ impl DnsUpdater {
         Ok(DnsUpdater::Bunny(BunnyProvider::new(api_key, timeout)?))
     }
 
+    /// Create a new DNS updater using the Infomaniak API.
+    pub fn new_infomaniak(api_key: impl AsRef<str>, timeout: Option<Duration>) -> crate::Result<Self> {
+        Ok(DnsUpdater::Infomaniak(InfomaniakProvider::new(api_key, timeout)?))
+    }
+
     /// Create a new DNS updater using the Porkbun API.
     pub fn new_porkbun(
         api_key: impl AsRef<str>,
@@ -214,6 +220,7 @@ impl DnsUpdater {
             DnsUpdater::Desec(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::DigitalOcean(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::DNSimple(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Infomaniak(provider) => provider.create(name, record, ttl, origin).await,
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.create(name, record, ttl, origin).await,
             DnsUpdater::Porkbun(provider) => provider.create(name, record, ttl, origin).await,
@@ -244,6 +251,7 @@ impl DnsUpdater {
             DnsUpdater::Desec(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::DigitalOcean(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::DNSimple(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Infomaniak(provider) => provider.update(name, record, ttl, origin).await,
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.update(name, record, ttl, origin).await,
             DnsUpdater::Porkbun(provider) => provider.update(name, record, ttl, origin).await,
@@ -273,6 +281,7 @@ impl DnsUpdater {
             DnsUpdater::Desec(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::DigitalOcean(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::DNSimple(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::Infomaniak(provider) => provider.delete(name, origin, record).await,
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             DnsUpdater::Ovh(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Porkbun(provider) => provider.delete(name, origin, record).await,


### PR DESCRIPTION
This pull request adds support for the provider Infomaniak. It introduces the new provider with create, update, and delete operations for DNS records via the API.
[Infomaniak API Docs](https://developer.infomaniak.com/docs/api/get/2/zones/%7Bzone%7D/records)

⚠️ The update and delete functions only get limited information on which DNS record to manipulate.
This is why they update or delete the first DNS record with matching domain and type. Usually this is the first record by creation time. If this is not the behavior expected by stalwart, please let me know how best to fix this.