### PR TITLE
feat(vercel): implement DNS provider with unit and integration tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use providers::{
     bunny::BunnyProvider, cloudflare::CloudflareProvider, desec::DesecProvider,
     digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, porkbun::PorkBunProvider,
     rfc2136::Rfc2136Provider, route53::Route53Provider, spaceship::SpaceshipProvider,
+    vercel::VercelProvider,
 };
 use std::{
     borrow::Cow,
@@ -202,6 +203,7 @@ pub enum DnsUpdater {
     #[cfg(feature = "test_provider")]
     InMemory(InMemoryProvider),
     Route53(Route53Provider),
+    Vercel(VercelProvider),
 }
 
 pub trait IntoFqdn<'x> {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -26,6 +26,7 @@ pub mod porkbun;
 pub mod rfc2136;
 pub mod route53;
 pub mod spaceship;
+pub mod vercel;
 
 impl DnsRecord {
     pub fn priority(&self) -> Option<u16> {

--- a/src/providers/vercel.rs
+++ b/src/providers/vercel.rs
@@ -1,0 +1,296 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use crate::{
+    http::HttpClientBuilder, utils::strip_origin_from_name, DnsRecord, DnsRecordType, Error,
+    IntoFqdn,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const DEFAULT_ENDPOINT: &str = "https://api.vercel.com";
+
+#[derive(Clone)]
+pub struct VercelProvider {
+    client: HttpClientBuilder,
+    team_id: Option<String>,
+    slug: Option<String>,
+    endpoint: String,
+}
+
+#[derive(Serialize, Debug)]
+struct VercelSrv {
+    target: String,
+    weight: u16,
+    port: u16,
+    priority: u16,
+}
+
+#[derive(Serialize, Debug)]
+struct VercelRecordRequest<'a> {
+    #[serde(rename = "type")]
+    record_type: &'a str,
+    name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ttl: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    comment: Option<&'a str>,
+    #[serde(rename = "mxPriority", skip_serializing_if = "Option::is_none")]
+    mx_priority: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    srv: Option<VercelSrv>,
+}
+
+#[derive(Deserialize, Debug)]
+struct VercelRecordListResponse {
+    pagination: Option<VercelPagination>,
+    records: Vec<VercelRecord>,
+}
+
+#[derive(Deserialize, Debug)]
+struct VercelPagination {
+    count: usize,
+    next: Option<u64>,
+}
+
+#[derive(Deserialize, Debug)]
+struct VercelRecord {
+    id: String,
+    name: String,
+    #[serde(rename = "type")]
+    record_type: String,
+}
+
+impl VercelProvider {
+    pub(crate) fn new(
+        token: impl AsRef<str>,
+        team_id: Option<String>,
+        slug: Option<String>,
+        timeout: Option<Duration>,
+    ) -> Self {
+        let client = HttpClientBuilder::default()
+            .with_header("Authorization", format!("Bearer {}", token.as_ref()))
+            .with_timeout(timeout);
+
+        Self {
+            client,
+            team_id,
+            slug,
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_endpoint(self, endpoint: impl AsRef<str>) -> Self {
+        Self {
+            endpoint: endpoint.as_ref().to_string(),
+            ..self
+        }
+    }
+
+    fn build_url(&self, path: &str, mut params: Vec<(&str, String)>) -> String {
+        let mut url = format!("{}{}", self.endpoint, path);
+        if let Some(team_id) = &self.team_id {
+            params.push(("teamId", team_id.clone()));
+        }
+        if let Some(slug) = &self.slug {
+            params.push(("slug", slug.clone()));
+        }
+        if !params.is_empty() {
+            let query = params
+                .into_iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join("&");
+            url.push('?');
+            url.push_str(&query);
+        }
+        url
+    }
+
+    /// Creates a new DNS record on Vercel
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let origin = origin.into_name();
+        let name = name.into_name();
+        // Vercel expects an empty string for the apex domain instead of '@'.
+        let subdomain = strip_origin_from_name(&name, &origin, Some(""));
+
+        let mut req = record_to_vercel(&record);
+        req.name = &subdomain;
+        req.ttl = Some(ttl);
+        req.comment = Some("Managed by Stalwart");
+
+        self.client
+            .post(self.build_url(&format!("/v2/domains/{}/records", origin), vec![]))
+            .with_body(req)?
+            .send_with_retry::<serde_json::Value>(3)
+            .await?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let origin = origin.into_name();
+        let name = name.into_name();
+        // Vercel expects an empty string for the apex domain instead of '@'.
+        let subdomain = strip_origin_from_name(&name, &origin, Some(""));
+        let record_type = record.as_type();
+
+        let record_id = self.find_record_id(&origin, &subdomain, record_type).await?;
+
+        let mut req = record_to_vercel(&record);
+        req.name = &subdomain;
+        req.ttl = Some(ttl);
+        req.comment = Some("Managed by Stalwart");
+
+        self.client
+            .patch(self.build_url(&format!("/v1/domains/records/{}", record_id), vec![]))
+            .with_body(req)?
+            .send_with_retry::<serde_json::Value>(3)
+            .await?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        origin: impl IntoFqdn<'_>,
+        record_type: DnsRecordType,
+    ) -> crate::Result<()> {
+        let origin = origin.into_name();
+        let name = name.into_name();
+        // Vercel expects an empty string for the apex domain instead of '@'.
+        let subdomain = strip_origin_from_name(&name, &origin, Some(""));
+
+        let record_id = self.find_record_id(&origin, &subdomain, record_type).await?;
+
+        self.client
+            .delete(self.build_url(
+                &format!("/v2/domains/{}/records/{}", origin, record_id),
+                vec![],
+            ))
+            .send_with_retry::<serde_json::Value>(3)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Finds the Vercel internal ID for a given DNS record.
+    /// Since Vercel requires IDs for updates and deletions, we need to locate it first.
+    /// Handles pagination natively by checking 'since' timestamp bounds.
+    async fn find_record_id(
+        &self,
+        origin: &str,
+        subdomain: &str,
+        record_type: DnsRecordType,
+    ) -> crate::Result<String> {
+        let record_type_str = record_type.as_str();
+        let mut since: Option<String> = None;
+
+        loop {
+            let mut params = vec![];
+            if let Some(s) = &since {
+                params.push(("since", s.clone()));
+            }
+
+            let response: VercelRecordListResponse = self
+                .client
+                .get(self.build_url(&format!("/v5/domains/{}/records", origin), params))
+                .send_with_retry(3)
+                .await?;
+
+            for record in &response.records {
+                if record.name == subdomain && record.record_type == record_type_str {
+                    return Ok(record.id.clone());
+                }
+            }
+
+            if let Some(pagination) = response.pagination {
+                if let Some(next) = pagination.next {
+                    since = Some(next.to_string());
+                    if pagination.count == 0 {
+                        break;
+                    }
+                    continue;
+                }
+            }
+
+            break;
+        }
+
+        Err(Error::NotFound)
+    }
+}
+
+fn record_to_vercel(record: &DnsRecord) -> VercelRecordRequest<'static> {
+    let mut req = VercelRecordRequest {
+        record_type: record.as_type().as_str(),
+        name: "",
+        value: None,
+        ttl: None,
+        comment: None,
+        mx_priority: None,
+        srv: None,
+    };
+
+    match record {
+        DnsRecord::A(ip) => req.value = Some(ip.to_string()),
+        DnsRecord::AAAA(ip) => req.value = Some(ip.to_string()),
+        DnsRecord::CNAME(target) => req.value = Some(target.to_string()),
+        DnsRecord::NS(target) => req.value = Some(target.to_string()),
+        DnsRecord::MX(mx) => {
+            req.value = Some(mx.exchange.clone());
+            req.mx_priority = Some(mx.priority);
+        }
+        DnsRecord::TXT(txt) => req.value = Some(txt.to_string()),
+        DnsRecord::SRV(srv) => {
+            req.srv = Some(VercelSrv {
+                target: srv.target.clone(),
+                weight: srv.weight,
+                port: srv.port,
+                priority: srv.priority,
+            });
+        }
+        DnsRecord::TLSA(tlsa) => {
+            req.value = Some(format!(
+                "{} {} {} {}",
+                u8::from(tlsa.cert_usage),
+                u8::from(tlsa.selector),
+                u8::from(tlsa.matching),
+                tlsa.cert_data
+                    .iter()
+                    .map(|b| format!("{:02x}", b))
+                    .collect::<String>()
+            ));
+        }
+        DnsRecord::CAA(caa) => {
+            let (flags, tag, value) = caa.clone().decompose();
+            req.value = Some(format!("{} {} \"{}\"", flags, tag, value));
+        }
+    }
+
+    req
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,3 +20,5 @@ pub mod porkbun_tests;
 #[cfg(test)]
 pub mod route53_tests;
 pub mod spaceship_tests;
+#[cfg(test)]
+pub mod vercel_tests;

--- a/src/tests/vercel_tests.rs
+++ b/src/tests/vercel_tests.rs
@@ -1,0 +1,207 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+#[cfg(test)]
+mod tests {
+    use crate::{DnsRecord, DnsRecordType, DnsUpdater, providers::vercel::VercelProvider};
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn setup_provider(endpoint: &str) -> VercelProvider {
+        VercelProvider::new(
+            "test_token",
+            Some("test_team".to_string()),
+            None,
+            Some(Duration::from_secs(1)),
+        )
+        .with_endpoint(endpoint)
+    }
+
+    #[test]
+    fn dns_updater_creation() {
+        let updater = DnsUpdater::new_vercel(
+            "test_token",
+            Some("test_team".to_string()),
+            None,
+            Some(Duration::from_secs(30)),
+        );
+
+        assert!(updater.is_ok());
+        assert!(
+            matches!(updater, Ok(DnsUpdater::Vercel(..))),
+            "Expected Vercel updater to provide a Vercel provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v2/domains/example.com/records")
+            .match_query(mockito::Matcher::UrlEncoded("teamId".into(), "test_team".into()))
+            .match_header("authorization", "Bearer test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "type": "A",
+                "name": "test",
+                "value": "1.1.1.1",
+                "ttl": 3600,
+                "comment": "Managed by Stalwart"
+            })))
+            .with_status(200)
+            .with_body(json!({"uid": "rec_123"}).to_string())
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::A("1.1.1.1".parse().unwrap()),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        result.expect("Failed to create record");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn update_record_success() {
+        let mut server = mockito::Server::new_async().await;
+        
+        // Mock list to find record ID
+        let list_mock = server
+            .mock("GET", "/v5/domains/example.com/records")
+            .match_query(mockito::Matcher::UrlEncoded("teamId".into(), "test_team".into()))
+            .with_status(200)
+            .with_body(json!({
+                "records": [
+                    {
+                        "id": "rec_123",
+                        "name": "test",
+                        "type": "A"
+                    }
+                ],
+                "pagination": {"count": 1, "next": null}
+            }).to_string())
+            .create();
+
+        let update_mock = server
+            .mock("PATCH", "/v1/domains/records/rec_123")
+            .match_query(mockito::Matcher::UrlEncoded("teamId".into(), "test_team".into()))
+            .match_body(mockito::Matcher::Json(json!({
+                "type": "A",
+                "name": "test",
+                "value": "8.8.8.8",
+                "ttl": 3600,
+                "comment": "Managed by Stalwart"
+            })))
+            .with_status(200)
+            .with_body("{}")
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .update(
+                "test.example.com",
+                DnsRecord::A("8.8.8.8".parse().unwrap()),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        result.expect("Failed to update record");
+        list_mock.assert();
+        update_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let list_mock = server
+            .mock("GET", "/v5/domains/example.com/records")
+            .match_query(mockito::Matcher::UrlEncoded("teamId".into(), "test_team".into()))
+            .with_status(200)
+            .with_body(json!({
+                "records": [
+                    {
+                        "id": "rec_123",
+                        "name": "test",
+                        "type": "TXT"
+                    }
+                ],
+                "pagination": {"count": 1, "next": null}
+            }).to_string())
+            .create();
+
+        let delete_mock = server
+            .mock("DELETE", "/v2/domains/example.com/records/rec_123")
+            .match_query(mockito::Matcher::UrlEncoded("teamId".into(), "test_team".into()))
+            .with_status(200)
+            .with_body("{}")
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+        let result = provider
+            .delete(
+                "test.example.com",
+                "example.com",
+                DnsRecordType::TXT,
+            )
+            .await;
+
+        result.expect("Failed to delete record");
+        list_mock.assert();
+        delete_mock.assert();
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires Vercel API keys and domain configuration"]
+    async fn vercel_integration_test() {
+        let token = std::env::var("VERCEL_TOKEN").unwrap_or_default();
+        let domain = std::env::var("VERCEL_DOMAIN").unwrap_or_default();
+        let origin = std::env::var("VERCEL_ORIGIN").unwrap_or_default();
+        let team_id = std::env::var("VERCEL_TEAM_ID").ok();
+        let slug = std::env::var("VERCEL_SLUG").ok();
+
+        assert!(
+            !token.is_empty(),
+            "Please configure your Vercel token in the integration test"
+        );
+        assert!(
+            !domain.is_empty(),
+            "Please configure your domain in the integration test"
+        );
+        assert!(
+            !origin.is_empty(),
+            "Please configure your origin in the integration test"
+        );
+
+        let updater = DnsUpdater::new_vercel(token, team_id, slug, Some(Duration::from_secs(30))).unwrap();
+
+        let create_result = updater
+            .create(&domain, DnsRecord::A([1, 1, 1, 1].into()), 60, &origin)
+            .await;
+        assert!(create_result.is_ok());
+
+        let update_result = updater
+            .update(&domain, DnsRecord::A([8, 8, 8, 8].into()), 60, &origin)
+            .await;
+        assert!(update_result.is_ok());
+
+        let delete_result = updater
+            .delete(&domain, &origin, crate::DnsRecordType::A)
+            .await;
+        assert!(delete_result.is_ok());
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -39,6 +39,7 @@ use crate::{
         rfc2136::{DnsAddress, Rfc2136Provider},
         route53::Route53Provider,
         spaceship::SpaceshipProvider,
+        vercel::VercelProvider,
     },
 };
 use std::time::Duration;
@@ -188,6 +189,18 @@ impl DnsUpdater {
         Ok(DnsUpdater::Route53(Route53Provider::new(config)))
     }
 
+    /// Create a new DNS updater using the Vercel API.
+    pub fn new_vercel(
+        token: impl AsRef<str>,
+        team_id: Option<String>,
+        slug: Option<String>,
+        timeout: Option<Duration>,
+    ) -> crate::Result<Self> {
+        Ok(DnsUpdater::Vercel(VercelProvider::new(
+            token, team_id, slug, timeout,
+        )))
+    }
+
     /// Create a new DNS updater using the Pebble Challenge Test Server.
     #[cfg(feature = "test_provider")]
     pub fn new_pebble(base_url: impl AsRef<str>, timeout: Option<Duration>) -> Self {
@@ -227,6 +240,7 @@ impl DnsUpdater {
             DnsUpdater::Pebble(provider) => provider.create(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::InMemory(provider) => provider.create(name, record, ttl, origin).await,
+            DnsUpdater::Vercel(provider) => provider.create(name, record, ttl, origin).await,
         }
     }
 
@@ -257,6 +271,7 @@ impl DnsUpdater {
             DnsUpdater::Pebble(provider) => provider.update(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::InMemory(provider) => provider.update(name, record, ttl, origin).await,
+            DnsUpdater::Vercel(provider) => provider.update(name, record, ttl, origin).await,
         }
     }
 
@@ -284,6 +299,7 @@ impl DnsUpdater {
             DnsUpdater::Pebble(provider) => provider.delete(name, origin, record).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::InMemory(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::Vercel(provider) => provider.delete(name, origin, record).await,
         }
     }
 }


### PR DESCRIPTION
Added Vercel DNS provider support.
The implementation includes unit tests using mockito and has been verified against the live Vercel API.
Handles pagination and domain apex formatting (empty string) natively.