### PR TITLE
Add Hetzner Cloud DNS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+dns-update 0.2.8
+================================
+- Hetzner Cloud DNS provider support.
+
 dns-update 0.2.7
 ================================
 - OVH + Google Cloud DNS: Fixes FQDN handling for `MX` and `SRV` records.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,9 @@ use providers::{in_memory::InMemoryProvider, pebble::PebbleProvider};
 pub use hickory_client::proto::dnssec;
 use providers::{
     bunny::BunnyProvider, cloudflare::CloudflareProvider, desec::DesecProvider,
-    digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, porkbun::PorkBunProvider,
-    rfc2136::Rfc2136Provider, route53::Route53Provider, spaceship::SpaceshipProvider,
+    digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, hetzner::HetznerProvider,
+    porkbun::PorkBunProvider, rfc2136::Rfc2136Provider, route53::Route53Provider,
+    spaceship::SpaceshipProvider,
 };
 use std::{
     borrow::Cow,
@@ -197,6 +198,7 @@ pub enum DnsUpdater {
     Spaceship(SpaceshipProvider),
     DNSimple(DNSimpleProvider),
     GoogleCloudDns(providers::google_cloud_dns::GoogleCloudDnsProvider),
+    Hetzner(HetznerProvider),
     #[cfg(feature = "test_provider")]
     Pebble(PebbleProvider),
     #[cfg(feature = "test_provider")]

--- a/src/providers/hetzner.rs
+++ b/src/providers/hetzner.rs
@@ -30,16 +30,6 @@ pub struct HetznerDnsRecordRepresentation {
     pub value: String,
 }
 
-#[derive(Serialize, Debug)]
-pub struct CreateRRSetRequest<'a> {
-    pub name: &'a str,
-    #[serde(rename = "type")]
-    pub rr_type: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ttl: Option<u32>,
-    pub records: Vec<RRSetRecord>,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RRSetRecord {
     pub value: String,
@@ -88,25 +78,46 @@ impl HetznerProvider {
         let subdomain = strip_origin_from_name(&name.into_name(), &zone, None);
         let hetzner_record = HetznerDnsRecordRepresentation::from(record);
 
+        // `add_records` appends to an existing RRSet, or auto-creates one if
+        // it does not exist. TTL is intentionally omitted: when an RRSet
+        // already exists, Hetzner rejects an `add_records` call whose TTL
+        // differs from the existing one. We enforce the caller's TTL via the
+        // follow-up `change_ttl` call below, so the caller's TTL always wins.
         self.client
             .post(format!(
-                "{endpoint}/zones/{zone}/rrsets",
+                "{endpoint}/zones/{zone}/rrsets/{rr_name}/{rr_type}/actions/add_records",
                 endpoint = self.endpoint,
                 zone = &zone,
+                rr_name = &subdomain,
+                rr_type = &hetzner_record.record_type,
             ))
-            .with_body(CreateRRSetRequest {
-                name: &subdomain,
-                rr_type: &hetzner_record.record_type,
-                ttl: Some(ttl),
+            .with_body(SetRecordsRequest {
                 records: vec![RRSetRecord {
                     value: hetzner_record.value,
                 }],
             })?
             .send_with_retry::<serde_json::Value>(3)
             .await
+            .map(|_| ())?;
+
+        self.client
+            .post(format!(
+                "{endpoint}/zones/{zone}/rrsets/{rr_name}/{rr_type}/actions/change_ttl",
+                endpoint = self.endpoint,
+                zone = &zone,
+                rr_name = &subdomain,
+                rr_type = &hetzner_record.record_type,
+            ))
+            .with_body(ChangeTtlRequest { ttl })?
+            .send_with_retry::<serde_json::Value>(3)
+            .await
             .map(|_| ())
     }
 
+    // Replaces every record in the (name, type) RRSet with the single
+    // provided record. Matches the RRSet-level semantics of `desec`,
+    // `route53`, and `google_cloud_dns`: the trait does not expose which
+    // specific record to overwrite, so the whole RRSet is rewritten.
     pub(crate) async fn update(
         &self,
         name: impl IntoFqdn<'_>,
@@ -149,6 +160,8 @@ impl HetznerProvider {
             .map(|_| ())
     }
 
+    // Removes the entire (name, type) RRSet. Matches the RRSet-level
+    // semantics of `desec`, `route53`, and `google_cloud_dns`.
     pub(crate) async fn delete(
         &self,
         name: impl IntoFqdn<'_>,

--- a/src/providers/hetzner.rs
+++ b/src/providers/hetzner.rs
@@ -1,0 +1,237 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use crate::{
+    DnsRecord, DnsRecordType, IntoFqdn,
+    http::HttpClientBuilder,
+    utils::{strip_origin_from_name, txt_chunks_to_text},
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const DEFAULT_ENDPOINT: &str = "https://api.hetzner.cloud/v1";
+
+#[derive(Clone)]
+pub struct HetznerProvider {
+    client: HttpClientBuilder,
+    endpoint: String,
+}
+
+pub struct HetznerDnsRecordRepresentation {
+    pub record_type: String,
+    pub value: String,
+}
+
+#[derive(Serialize, Debug)]
+pub struct CreateRRSetRequest<'a> {
+    pub name: &'a str,
+    #[serde(rename = "type")]
+    pub rr_type: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u32>,
+    pub records: Vec<RRSetRecord>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RRSetRecord {
+    pub value: String,
+}
+
+#[derive(Serialize, Debug)]
+pub struct SetRecordsRequest {
+    pub records: Vec<RRSetRecord>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct ChangeTtlRequest {
+    pub ttl: u32,
+}
+
+#[derive(Deserialize, Debug)]
+struct EmptyResponse {}
+
+impl HetznerProvider {
+    pub(crate) fn new(api_token: impl AsRef<str>, timeout: Option<Duration>) -> Self {
+        let client = HttpClientBuilder::default()
+            .with_header("Authorization", format!("Bearer {}", api_token.as_ref()))
+            .with_timeout(timeout);
+        Self {
+            client,
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_endpoint(self, endpoint: impl AsRef<str>) -> Self {
+        Self {
+            endpoint: endpoint.as_ref().to_string(),
+            ..self
+        }
+    }
+
+    pub(crate) async fn create(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let zone = origin.into_name();
+        let subdomain = strip_origin_from_name(&name.into_name(), &zone, None);
+        let hetzner_record = HetznerDnsRecordRepresentation::from(record);
+
+        self.client
+            .post(format!(
+                "{endpoint}/zones/{zone}/rrsets",
+                endpoint = self.endpoint,
+                zone = &zone,
+            ))
+            .with_body(CreateRRSetRequest {
+                name: &subdomain,
+                rr_type: &hetzner_record.record_type,
+                ttl: Some(ttl),
+                records: vec![RRSetRecord {
+                    value: hetzner_record.value,
+                }],
+            })?
+            .send_with_retry::<serde_json::Value>(3)
+            .await
+            .map(|_| ())
+    }
+
+    pub(crate) async fn update(
+        &self,
+        name: impl IntoFqdn<'_>,
+        record: DnsRecord,
+        ttl: u32,
+        origin: impl IntoFqdn<'_>,
+    ) -> crate::Result<()> {
+        let zone = origin.into_name();
+        let subdomain = strip_origin_from_name(&name.into_name(), &zone, None);
+        let hetzner_record = HetznerDnsRecordRepresentation::from(record);
+
+        self.client
+            .post(format!(
+                "{endpoint}/zones/{zone}/rrsets/{rr_name}/{rr_type}/actions/set_records",
+                endpoint = self.endpoint,
+                zone = &zone,
+                rr_name = &subdomain,
+                rr_type = &hetzner_record.record_type,
+            ))
+            .with_body(SetRecordsRequest {
+                records: vec![RRSetRecord {
+                    value: hetzner_record.value,
+                }],
+            })?
+            .send_with_retry::<serde_json::Value>(3)
+            .await
+            .map(|_| ())?;
+
+        self.client
+            .post(format!(
+                "{endpoint}/zones/{zone}/rrsets/{rr_name}/{rr_type}/actions/change_ttl",
+                endpoint = self.endpoint,
+                zone = &zone,
+                rr_name = &subdomain,
+                rr_type = &hetzner_record.record_type,
+            ))
+            .with_body(ChangeTtlRequest { ttl })?
+            .send_with_retry::<serde_json::Value>(3)
+            .await
+            .map(|_| ())
+    }
+
+    pub(crate) async fn delete(
+        &self,
+        name: impl IntoFqdn<'_>,
+        origin: impl IntoFqdn<'_>,
+        record_type: DnsRecordType,
+    ) -> crate::Result<()> {
+        let zone = origin.into_name();
+        let subdomain = strip_origin_from_name(&name.into_name(), &zone, None);
+
+        self.client
+            .delete(format!(
+                "{endpoint}/zones/{zone}/rrsets/{rr_name}/{rr_type}",
+                endpoint = self.endpoint,
+                zone = &zone,
+                rr_name = &subdomain,
+                rr_type = record_type.as_str(),
+            ))
+            .send_with_retry::<EmptyResponse>(3)
+            .await
+            .map(|_| ())
+    }
+}
+
+fn ensure_fqdn(name: String) -> String {
+    if name.ends_with('.') {
+        name
+    } else {
+        format!("{name}.")
+    }
+}
+
+/// Converts a DNS record into a representation that can be sent to the
+/// Hetzner Cloud DNS API. Values are encoded in standard DNS zone-file
+/// format, as accepted by the Zone RRSets endpoints.
+impl From<DnsRecord> for HetznerDnsRecordRepresentation {
+    fn from(record: DnsRecord) -> Self {
+        match record {
+            DnsRecord::A(content) => HetznerDnsRecordRepresentation {
+                record_type: "A".to_string(),
+                value: content.to_string(),
+            },
+            DnsRecord::AAAA(content) => HetznerDnsRecordRepresentation {
+                record_type: "AAAA".to_string(),
+                value: content.to_string(),
+            },
+            DnsRecord::CNAME(content) => HetznerDnsRecordRepresentation {
+                record_type: "CNAME".to_string(),
+                value: ensure_fqdn(content),
+            },
+            DnsRecord::NS(content) => HetznerDnsRecordRepresentation {
+                record_type: "NS".to_string(),
+                value: ensure_fqdn(content),
+            },
+            DnsRecord::MX(mx) => HetznerDnsRecordRepresentation {
+                record_type: "MX".to_string(),
+                value: format!("{} {}", mx.priority, ensure_fqdn(mx.exchange)),
+            },
+            DnsRecord::TXT(content) => {
+                let mut value = String::new();
+                txt_chunks_to_text(&mut value, &content, " ");
+                HetznerDnsRecordRepresentation {
+                    record_type: "TXT".to_string(),
+                    value,
+                }
+            }
+            DnsRecord::SRV(srv) => HetznerDnsRecordRepresentation {
+                record_type: "SRV".to_string(),
+                value: format!(
+                    "{} {} {} {}",
+                    srv.priority,
+                    srv.weight,
+                    srv.port,
+                    ensure_fqdn(srv.target)
+                ),
+            },
+            DnsRecord::TLSA(tlsa) => HetznerDnsRecordRepresentation {
+                record_type: "TLSA".to_string(),
+                value: tlsa.to_string(),
+            },
+            DnsRecord::CAA(caa) => HetznerDnsRecordRepresentation {
+                record_type: "CAA".to_string(),
+                value: caa.to_string(),
+            },
+        }
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -17,6 +17,7 @@ pub mod desec;
 pub mod digitalocean;
 pub mod dnsimple;
 pub mod google_cloud_dns;
+pub mod hetzner;
 #[cfg(feature = "test_provider")]
 pub mod in_memory;
 pub mod ovh;

--- a/src/tests/hetzner_tests.rs
+++ b/src/tests/hetzner_tests.rs
@@ -1,0 +1,279 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        DnsRecord, DnsRecordType, DnsUpdater, MXRecord, providers::hetzner::HetznerProvider,
+    };
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn setup_provider(endpoint: &str) -> HetznerProvider {
+        HetznerProvider::new("test_token", Some(Duration::from_secs(1))).with_endpoint(endpoint)
+    }
+
+    #[test]
+    fn dns_updater_creation() {
+        let updater = DnsUpdater::new_hetzner("test_token", Some(Duration::from_secs(30)));
+
+        assert!(updater.is_ok());
+        assert!(
+            matches!(updater, Ok(DnsUpdater::Hetzner(..))),
+            "Expected Hetzner updater to provide a Hetzner provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_a_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/zones/example.com/rrsets")
+            .match_header("authorization", "Bearer test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "name": "test",
+                "type": "A",
+                "ttl": 3600,
+                "records": [{"value": "1.1.1.1"}],
+            })))
+            .with_status(201)
+            .with_body(
+                r#"{"rrset":{"id":"test/A","name":"test","type":"A","ttl":3600,"labels":{},"protection":{"change":false},"records":[{"value":"1.1.1.1"}],"zone":42}}"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::A("1.1.1.1".parse().unwrap()),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn create_apex_record_uses_at_sign() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/zones/example.com/rrsets")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({
+                "name": "@",
+                "type": "A",
+                "ttl": 3600,
+                "records": [{"value": "1.2.3.4"}],
+            })))
+            .with_status(201)
+            .with_body(
+                r#"{"rrset":{"id":"@/A","name":"@","type":"A","ttl":3600,"labels":{},"protection":{"change":false},"records":[{"value":"1.2.3.4"}],"zone":42}}"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .create(
+                "example.com",
+                DnsRecord::A("1.2.3.4".parse().unwrap()),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn create_mx_record_serializes_priority_in_value() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/zones/example.com/rrsets")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({
+                "name": "test",
+                "type": "MX",
+                "ttl": 3600,
+                "records": [{"value": "10 mail.example.com."}],
+            })))
+            .with_status(201)
+            .with_body(
+                r#"{"rrset":{"id":"test/MX","name":"test","type":"MX","ttl":3600,"labels":{},"protection":{"change":false},"records":[{"value":"10 mail.example.com."}],"zone":42}}"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .create(
+                "test.example.com",
+                DnsRecord::MX(MXRecord {
+                    exchange: "mail.example.com".to_string(),
+                    priority: 10,
+                }),
+                3600,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn create_txt_record_quotes_value() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/zones/example.com/rrsets")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({
+                "name": "_acme-challenge",
+                "type": "TXT",
+                "ttl": 60,
+                "records": [{"value": "\"challenge-value\""}],
+            })))
+            .with_status(201)
+            .with_body(
+                r#"{"rrset":{"id":"_acme-challenge/TXT","name":"_acme-challenge","type":"TXT","ttl":60,"labels":{},"protection":{"change":false},"records":[{"value":"\"challenge-value\""}],"zone":42}}"#,
+            )
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .create(
+                "_acme-challenge.example.com",
+                DnsRecord::TXT("challenge-value".to_string()),
+                60,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn create_long_txt_record_splits_into_255_byte_chunks() {
+        let mut server = mockito::Server::new_async().await;
+        let long = "a".repeat(400);
+        let expected_value = format!("\"{}\" \"{}\"", "a".repeat(255), "a".repeat(145));
+
+        let mock = server
+            .mock("POST", "/zones/example.com/rrsets")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({
+                "name": "long",
+                "type": "TXT",
+                "ttl": 60,
+                "records": [{"value": expected_value}],
+            })))
+            .with_status(201)
+            .with_body(r#"{"rrset":{"id":"long/TXT","name":"long","type":"TXT","ttl":60,"labels":{},"protection":{"change":false},"records":[],"zone":42}}"#)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .create(
+                "long.example.com",
+                DnsRecord::TXT(long),
+                60,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok(), "{:?}", result);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn update_record_calls_set_records_and_change_ttl() {
+        let mut server = mockito::Server::new_async().await;
+
+        let set_records_mock = server
+            .mock("POST", "/zones/example.com/rrsets/www/AAAA/actions/set_records")
+            .match_header("authorization", "Bearer test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "records": [{"value": "2001:db8::2"}],
+            })))
+            .with_status(201)
+            .with_body(r#"{"action":{"id":1,"status":"success"}}"#)
+            .create();
+
+        let change_ttl_mock = server
+            .mock("POST", "/zones/example.com/rrsets/www/AAAA/actions/change_ttl")
+            .match_header("authorization", "Bearer test_token")
+            .match_header("content-type", "application/json")
+            .match_body(mockito::Matcher::Json(json!({
+                "ttl": 7200,
+            })))
+            .with_status(201)
+            .with_body(r#"{"action":{"id":2,"status":"success"}}"#)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .update(
+                "www.example.com",
+                DnsRecord::AAAA("2001:db8::2".parse().unwrap()),
+                7200,
+                "example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+        set_records_mock.assert();
+        change_ttl_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_record_success() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("DELETE", "/zones/example.com/rrsets/test/TXT")
+            .match_header("authorization", "Bearer test_token")
+            .with_status(204)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .delete("test.example.com", "example.com", DnsRecordType::TXT)
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_apex_record_uses_at_sign() {
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("DELETE", "/zones/example.com/rrsets/@/A")
+            .match_header("authorization", "Bearer test_token")
+            .with_status(204)
+            .create();
+
+        let provider = setup_provider(server.url().as_str());
+
+        let result = provider
+            .delete("example.com", "example.com", DnsRecordType::A)
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert();
+    }
+}

--- a/src/tests/hetzner_tests.rs
+++ b/src/tests/hetzner_tests.rs
@@ -25,20 +25,23 @@ mod tests {
     async fn create_a_record_success() {
         let mut server = mockito::Server::new_async().await;
 
-        let mock = server
-            .mock("POST", "/zones/example.com/rrsets")
+        let add_records_mock = server
+            .mock("POST", "/zones/example.com/rrsets/test/A/actions/add_records")
             .match_header("authorization", "Bearer test_token")
             .match_header("content-type", "application/json")
             .match_body(mockito::Matcher::Json(json!({
-                "name": "test",
-                "type": "A",
-                "ttl": 3600,
                 "records": [{"value": "1.1.1.1"}],
             })))
             .with_status(201)
-            .with_body(
-                r#"{"rrset":{"id":"test/A","name":"test","type":"A","ttl":3600,"labels":{},"protection":{"change":false},"records":[{"value":"1.1.1.1"}],"zone":42}}"#,
-            )
+            .with_body(r#"{"action":{"id":1,"status":"success"}}"#)
+            .create();
+
+        let change_ttl_mock = server
+            .mock("POST", "/zones/example.com/rrsets/test/A/actions/change_ttl")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({"ttl": 3600})))
+            .with_status(201)
+            .with_body(r#"{"action":{"id":2,"status":"success"}}"#)
             .create();
 
         let provider = setup_provider(server.url().as_str());
@@ -53,26 +56,30 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
-        mock.assert();
+        add_records_mock.assert();
+        change_ttl_mock.assert();
     }
 
     #[tokio::test]
     async fn create_apex_record_uses_at_sign() {
         let mut server = mockito::Server::new_async().await;
 
-        let mock = server
-            .mock("POST", "/zones/example.com/rrsets")
+        let add_records_mock = server
+            .mock("POST", "/zones/example.com/rrsets/@/A/actions/add_records")
             .match_header("authorization", "Bearer test_token")
             .match_body(mockito::Matcher::Json(json!({
-                "name": "@",
-                "type": "A",
-                "ttl": 3600,
                 "records": [{"value": "1.2.3.4"}],
             })))
             .with_status(201)
-            .with_body(
-                r#"{"rrset":{"id":"@/A","name":"@","type":"A","ttl":3600,"labels":{},"protection":{"change":false},"records":[{"value":"1.2.3.4"}],"zone":42}}"#,
-            )
+            .with_body(r#"{"action":{"id":1,"status":"success"}}"#)
+            .create();
+
+        let change_ttl_mock = server
+            .mock("POST", "/zones/example.com/rrsets/@/A/actions/change_ttl")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({"ttl": 3600})))
+            .with_status(201)
+            .with_body(r#"{"action":{"id":2,"status":"success"}}"#)
             .create();
 
         let provider = setup_provider(server.url().as_str());
@@ -87,26 +94,30 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
-        mock.assert();
+        add_records_mock.assert();
+        change_ttl_mock.assert();
     }
 
     #[tokio::test]
     async fn create_mx_record_serializes_priority_in_value() {
         let mut server = mockito::Server::new_async().await;
 
-        let mock = server
-            .mock("POST", "/zones/example.com/rrsets")
+        let add_records_mock = server
+            .mock("POST", "/zones/example.com/rrsets/test/MX/actions/add_records")
             .match_header("authorization", "Bearer test_token")
             .match_body(mockito::Matcher::Json(json!({
-                "name": "test",
-                "type": "MX",
-                "ttl": 3600,
                 "records": [{"value": "10 mail.example.com."}],
             })))
             .with_status(201)
-            .with_body(
-                r#"{"rrset":{"id":"test/MX","name":"test","type":"MX","ttl":3600,"labels":{},"protection":{"change":false},"records":[{"value":"10 mail.example.com."}],"zone":42}}"#,
-            )
+            .with_body(r#"{"action":{"id":1,"status":"success"}}"#)
+            .create();
+
+        let change_ttl_mock = server
+            .mock("POST", "/zones/example.com/rrsets/test/MX/actions/change_ttl")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({"ttl": 3600})))
+            .with_status(201)
+            .with_body(r#"{"action":{"id":2,"status":"success"}}"#)
             .create();
 
         let provider = setup_provider(server.url().as_str());
@@ -124,26 +135,36 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
-        mock.assert();
+        add_records_mock.assert();
+        change_ttl_mock.assert();
     }
 
     #[tokio::test]
     async fn create_txt_record_quotes_value() {
         let mut server = mockito::Server::new_async().await;
 
-        let mock = server
-            .mock("POST", "/zones/example.com/rrsets")
+        let add_records_mock = server
+            .mock(
+                "POST",
+                "/zones/example.com/rrsets/_acme-challenge/TXT/actions/add_records",
+            )
             .match_header("authorization", "Bearer test_token")
             .match_body(mockito::Matcher::Json(json!({
-                "name": "_acme-challenge",
-                "type": "TXT",
-                "ttl": 60,
                 "records": [{"value": "\"challenge-value\""}],
             })))
             .with_status(201)
-            .with_body(
-                r#"{"rrset":{"id":"_acme-challenge/TXT","name":"_acme-challenge","type":"TXT","ttl":60,"labels":{},"protection":{"change":false},"records":[{"value":"\"challenge-value\""}],"zone":42}}"#,
+            .with_body(r#"{"action":{"id":1,"status":"success"}}"#)
+            .create();
+
+        let change_ttl_mock = server
+            .mock(
+                "POST",
+                "/zones/example.com/rrsets/_acme-challenge/TXT/actions/change_ttl",
             )
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({"ttl": 60})))
+            .with_status(201)
+            .with_body(r#"{"action":{"id":2,"status":"success"}}"#)
             .create();
 
         let provider = setup_provider(server.url().as_str());
@@ -158,7 +179,8 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
-        mock.assert();
+        add_records_mock.assert();
+        change_ttl_mock.assert();
     }
 
     #[tokio::test]
@@ -167,17 +189,22 @@ mod tests {
         let long = "a".repeat(400);
         let expected_value = format!("\"{}\" \"{}\"", "a".repeat(255), "a".repeat(145));
 
-        let mock = server
-            .mock("POST", "/zones/example.com/rrsets")
+        let add_records_mock = server
+            .mock("POST", "/zones/example.com/rrsets/long/TXT/actions/add_records")
             .match_header("authorization", "Bearer test_token")
             .match_body(mockito::Matcher::Json(json!({
-                "name": "long",
-                "type": "TXT",
-                "ttl": 60,
                 "records": [{"value": expected_value}],
             })))
             .with_status(201)
-            .with_body(r#"{"rrset":{"id":"long/TXT","name":"long","type":"TXT","ttl":60,"labels":{},"protection":{"change":false},"records":[],"zone":42}}"#)
+            .with_body(r#"{"action":{"id":1,"status":"success"}}"#)
+            .create();
+
+        let change_ttl_mock = server
+            .mock("POST", "/zones/example.com/rrsets/long/TXT/actions/change_ttl")
+            .match_header("authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(json!({"ttl": 60})))
+            .with_status(201)
+            .with_body(r#"{"action":{"id":2,"status":"success"}}"#)
             .create();
 
         let provider = setup_provider(server.url().as_str());
@@ -192,7 +219,8 @@ mod tests {
             .await;
 
         assert!(result.is_ok(), "{:?}", result);
-        mock.assert();
+        add_records_mock.assert();
+        change_ttl_mock.assert();
     }
 
     #[tokio::test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,6 +13,7 @@ pub mod bunny_test;
 pub mod desec_tests;
 pub mod dnsimple_tests;
 pub mod google_cloud_dns_tests;
+pub mod hetzner_tests;
 #[cfg(test)]
 pub mod lib_tests;
 pub mod ovh_tests;

--- a/src/update.rs
+++ b/src/update.rs
@@ -35,6 +35,7 @@ use crate::{
         desec::DesecProvider,
         digitalocean::DigitalOceanProvider,
         dnsimple::DNSimpleProvider,
+        hetzner::HetznerProvider,
         porkbun::PorkBunProvider,
         rfc2136::{DnsAddress, Rfc2136Provider},
         route53::Route53Provider,
@@ -188,6 +189,16 @@ impl DnsUpdater {
         Ok(DnsUpdater::Route53(Route53Provider::new(config)))
     }
 
+    /// Create a new DNS updater using the Hetzner Cloud DNS API.
+    pub fn new_hetzner(
+        api_token: impl AsRef<str>,
+        timeout: Option<Duration>,
+    ) -> crate::Result<Self> {
+        Ok(DnsUpdater::Hetzner(HetznerProvider::new(
+            api_token, timeout,
+        )))
+    }
+
     /// Create a new DNS updater using the Pebble Challenge Test Server.
     #[cfg(feature = "test_provider")]
     pub fn new_pebble(base_url: impl AsRef<str>, timeout: Option<Duration>) -> Self {
@@ -223,6 +234,7 @@ impl DnsUpdater {
             DnsUpdater::GoogleCloudDns(provider) => {
                 provider.create(name, record, ttl, origin).await
             }
+            DnsUpdater::Hetzner(provider) => provider.create(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::Pebble(provider) => provider.create(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
@@ -253,6 +265,7 @@ impl DnsUpdater {
             DnsUpdater::GoogleCloudDns(provider) => {
                 provider.update(name, record, ttl, origin).await
             }
+            DnsUpdater::Hetzner(provider) => provider.update(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::Pebble(provider) => provider.update(name, record, ttl, origin).await,
             #[cfg(feature = "test_provider")]
@@ -280,6 +293,7 @@ impl DnsUpdater {
             DnsUpdater::Route53(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::Spaceship(provider) => provider.delete(name, origin, record).await,
             DnsUpdater::GoogleCloudDns(provider) => provider.delete(name, origin, record).await,
+            DnsUpdater::Hetzner(provider) => provider.delete(name, origin, record).await,
             #[cfg(feature = "test_provider")]
             DnsUpdater::Pebble(provider) => provider.delete(name, origin, record).await,
             #[cfg(feature = "test_provider")]


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
  Adds a Hetzner Cloud DNS provider, implementing the `DnsUpdater` trait                                                                                                                      
  for create / update / delete across the standard record types                                                                                                                               
  (`A`, `AAAA`, `CNAME`, `NS`, `MX`, `TXT`, `SRV`, `CAA`, `TLSA`).
                                                                                                                                                                                              
  The provider talks to the Hetzner DNS Console API
  (<https://dns.hetzner.com/api-docs>) using the existing `HttpClient`,                                                                                                                       
  authenticated via the `Auth-API-Token` header. Zone lookup walks the                                                                                                                        
  record's parent domain to find the matching Hetzner zone, mirroring how
  the Cloudflare provider handles subdomain zones.                                                                                                                                            
                  
  ## Notes                                                                                                                                                                                    
  - Record names are stored as subdomain-relative (Hetzner's API expects
    `@` for the apex, not the FQDN), matching the convention used by the
    Bunny provider after #41.                                                                                                                                                                 
  - TXT values are split into 255-char quoted chunks via the existing
    `txt_chunks_to_text` helper, so long records like DKIM keys are                                                                                                                           
    handled the same way as in RFC2136 / Google Cloud DNS.                                                                                                                                    
                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                
  - [x] Unit tests in `src/tests/hetzner_tests.rs` (serialization +                                                                                                                           
        response parsing).                                                                                                                                                                    
  - [x] Manual end-to-end run against a real Hetzner zone for each record
        type. 