### PR TITLE
Fix Cloudflare update 404 by resolving record ID before PATCH

### DIFF
--- a/src/providers/cloudflare.rs
+++ b/src/providers/cloudflare.rs
@@ -220,12 +220,14 @@ impl CloudflareProvider {
         ttl: u32,
         origin: impl IntoFqdn<'_>,
     ) -> crate::Result<()> {
+        let zone_id = self.obtain_zone_id(origin).await?;
         let name = name.into_name();
+        let record_id = self
+            .obtain_record_id(&zone_id, name.as_ref(), record.as_type())
+            .await?;
         self.client
             .patch(format!(
-                "https://api.cloudflare.com/client/v4/zones/{}/dns_records/{}",
-                self.obtain_zone_id(origin).await?,
-                name.as_ref()
+                "https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records/{record_id}",
             ))
             .with_body(UpdateDnsRecordParams {
                 ttl: ttl.into(),

--- a/src/tests/cloudflare_tests.rs
+++ b/src/tests/cloudflare_tests.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright Stalwart Labs LLC See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+#[cfg(test)]
+mod tests {
+    use crate::{DnsRecord, DnsRecordType, DnsUpdater, providers::cloudflare::CloudflareProvider};
+    use std::time::Duration;
+
+    #[tokio::test]
+    #[ignore = "Requires Cloudflare API token, zone, and FQDN"]
+    async fn integration_test() {
+        let token = std::env::var("CLOUDFLARE_API_TOKEN").unwrap_or_default();
+        let origin = std::env::var("CLOUDFLARE_ORIGIN").unwrap_or_default();
+        let fqdn = std::env::var("CLOUDFLARE_FQDN").unwrap_or_default();
+
+        assert!(
+            !token.is_empty(),
+            "Set CLOUDFLARE_API_TOKEN to run this test"
+        );
+        assert!(
+            !origin.is_empty(),
+            "Set CLOUDFLARE_ORIGIN to run this test (e.g. example.com)"
+        );
+        assert!(
+            !fqdn.is_empty(),
+            "Set CLOUDFLARE_FQDN to run this test (e.g. test.example.com)"
+        );
+
+        let updater =
+            DnsUpdater::new_cloudflare(token, None::<&str>, Some(Duration::from_secs(30)))
+                .unwrap();
+
+        let create_result = updater
+            .create(&fqdn, DnsRecord::A([1, 1, 1, 1].into()), 300, &origin)
+            .await;
+        assert!(create_result.is_ok(), "create failed: {create_result:?}");
+
+        let update_result = updater
+            .update(&fqdn, DnsRecord::A([8, 8, 8, 8].into()), 300, &origin)
+            .await;
+        assert!(update_result.is_ok(), "update failed: {update_result:?}");
+
+        let delete_result = updater.delete(&fqdn, &origin, DnsRecordType::A).await;
+        assert!(delete_result.is_ok(), "delete failed: {delete_result:?}");
+    }
+
+    #[test]
+    fn provider_creation() {
+        let provider = CloudflareProvider::new(
+            "cf-mock-token",
+            None::<&str>,
+            Some(Duration::from_secs(1)),
+        );
+
+        assert!(provider.is_ok());
+    }
+
+    #[test]
+    fn dns_updater_creation() {
+        let updater = DnsUpdater::new_cloudflare(
+            "cf-mock-token",
+            None::<&str>,
+            Some(Duration::from_secs(30)),
+        );
+
+        assert!(
+            matches!(updater, Ok(DnsUpdater::Cloudflare(..))),
+            "Expected Cloudflare updater to provide a Cloudflare provider"
+        );
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,7 @@
  */
 
 pub mod bunny_test;
+pub mod cloudflare_tests;
 pub mod desec_tests;
 pub mod dnsimple_tests;
 pub mod google_cloud_dns_tests;


### PR DESCRIPTION
Fixes #51 

Fix `CloudflareProvider::update` returning 405 by resolving the record ID before issuing the PATCH. Previously the FQDN was placed in the `{record_id}` URL segment, which Cloudflare always rejects

Added a simple test for Cloudflare that tests `create`, `update` and `delete` functionalities