### PR TITLE
fix(dns-update): Enforce deSEC API requirements for TTL, TXT records, and subnames

### DIFF
--- a/src/providers/desec.rs
+++ b/src/providers/desec.rs
@@ -15,6 +15,9 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+/// Minimum TTL required by deSEC
+const MIN_TTL: u32 = 3600;
+
 pub struct DesecDnsRecordRepresentation {
     pub record_type: String,
     pub content: String,
@@ -56,6 +59,31 @@ struct DesecEmptyResponse {}
 /// The default endpoint for the desec API.
 const DEFAULT_API_ENDPOINT: &str = "https://desec.io/api/v1";
 
+/// Normalizes TXT record content by removing parentheses, newlines, and extra whitespace
+fn normalize_txt_content(content: &str) -> String {
+    content
+        .replace('(', "")
+        .replace(')', "")
+        .replace('\n', "")
+        .replace('\r', "")
+        .replace(' ', "")
+}
+
+/// Validates that a subname only contains allowed characters (a-z, 0-9, ., -, _)
+/// and is lowercase. Returns the subname if valid, otherwise returns an error.
+fn validate_subname(subname: &str) -> crate::Result<()> {
+    if subname.is_empty() {
+        return Ok(());
+    }
+    if !subname
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-' || c == '_')
+    {
+        return Err(crate::DnsError::InvalidSubname(subname.to_string()).into());
+    }
+    Ok(())
+}
+
 impl DesecProvider {
     pub(crate) fn new(auth_token: impl AsRef<str>, timeout: Option<Duration>) -> Self {
         let client = HttpClientBuilder::default()
@@ -87,6 +115,12 @@ impl DesecProvider {
         let domain = origin.into_name();
         let subdomain = strip_origin_from_name(&name, &domain, None);
 
+        // Validate subname
+        validate_subname(&subdomain)?;
+
+        // Enforce minimum TTL
+        let ttl = std::cmp::max(ttl, MIN_TTL);
+
         let desec_record = DesecDnsRecordRepresentation::from(record);
         self.client
             .post(format!(
@@ -115,6 +149,12 @@ impl DesecProvider {
         let name = name.into_name();
         let domain = origin.into_name();
         let subdomain = strip_origin_from_name(&name, &domain, None);
+
+        // Validate subname
+        validate_subname(&subdomain)?;
+
+        // Enforce minimum TTL
+        let ttl = std::cmp::max(ttl, MIN_TTL);
 
         let desec_record = DesecDnsRecordRepresentation::from(record);
         self.client
@@ -195,7 +235,7 @@ impl From<DnsRecord> for DesecDnsRecordRepresentation {
             },
             DnsRecord::TXT(content) => DesecDnsRecordRepresentation {
                 record_type: "TXT".to_string(),
-                content: format!("\"{content}\""),
+                content: format!("\"{}\"", normalize_txt_content(&content)),
             },
             DnsRecord::SRV(srv) => DesecDnsRecordRepresentation {
                 record_type: "SRV".to_string(),


### PR DESCRIPTION
## Summary
Fixes DNS record push failures to deSEC by enforcing API requirements:
- **TTL**: Ensures all records use a minimum TTL of 3600 seconds (deSEC requirement).
- **TXT Records**: Normalizes multi-line TXT records (e.g., DKIM) by removing parentheses, newlines, and extra whitespace.
- **Subnames**: Validates that subnames only contain lowercase `a-z`, `0-9`, `.`, `-`, and `_`.

## Problem
Stalwart was failing to push DNS zones to deSEC with errors:
- `{"ttl":["Ensure this value is greater than or equal to 3600."]}`
- Multi-line TXT records (e.g., DKIM keys) were rejected due to parentheses/newlines.
- Subnames with invalid characters caused API rejections.

## Changes
- Added `MIN_TTL = 3600` constant and enforced it in `create()`/`update()`.
- Added `normalize_txt_content()` to clean TXT record values.
- Added `validate_subname()` to check subname characters before pushing.

## Testing
- Tested with a zone file containing DKIM, SPF, DMARC, MX, SRV, and CAA records.
- Verified all records are accepted by deSEC API.

## Related
Closes issues with DNS zone pushes failing due to deSEC API validation errors.