### PR TITLE
Update hickory to v0.26 which drops support for SIG(0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,20 @@ resolver = "2"
 [features]
 default = ["aws-lc-rs"]
 ring = [
-    "hickory-client/dnssec-ring",
-    "hickory-client/tls-ring",
-    "hickory-client/https-ring",
+    "hickory-proto/dnssec-ring",
+    "hickory-net/dnssec-ring",
+    "hickory-net/tls-ring",
+    "hickory-net/https-ring",
     "dep:ring",
     "reqwest/native-tls",
     "rustls",
     "rustls/ring",
 ]
 aws-lc-rs = [
-    "hickory-client/dnssec-aws-lc-rs",
-    "hickory-client/tls-aws-lc-rs",
-    "hickory-client/https-aws-lc-rs",
+    "hickory-proto/dnssec-aws-lc-rs",
+    "hickory-net/dnssec-aws-lc-rs",
+    "hickory-net/tls-aws-lc-rs",
+    "hickory-net/https-aws-lc-rs",
     "dep:aws-lc-rs",
     "reqwest/rustls",
     "rustls",
@@ -36,9 +38,10 @@ test_provider = []
 
 [dependencies]
 base64 = { version = "0.22.1", default-features = false, features = ["std"] }
-tokio = { version = "1.51", features = ["rt", "net"] }
+tokio = { version = "1.52", features = ["rt", "net"] }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
-hickory-client = { version = "0.25", default-features = false }
+hickory-net = { version = "0.26.1", default-features = false }
+hickory-proto = { version = "0.26.1", default-features = false, features = ["std"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0.116", default-features = false, features = ["std"] }
 reqwest = { version = "0.13", default-features = false, features = ["http2", "gzip", "deflate", "json"]}
@@ -46,7 +49,7 @@ serde_urlencoded = { version = "0.7.1", default-features = false }
 ring = { version = "0.17", optional = true }
 aws-lc-rs = { version = "1.16", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
-quick-xml = { version = "0.39.2", features = ["serialize"] }
+quick-xml = { version = "0.39.4", features = ["serialize"] }
 chrono = { version = "0.4" , default-features = false, features = ["std", "clock", "now"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ and different cloud provider APIs such as [Cloudflare](https://www.cloudflare.co
 ## Limitations
  
 - Currently the library is `async` only.
-- Besides RFC 2136, it only supports a few cloud providers API. 
+- Besides RFC 2136, it only supports a few cloud providers API.
+- SIG(0) authentication for RFC 2136 is not supported (removed in hickory v0.26). Use TSIG instead. 
 
 ## PRs Welcome
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use providers::ovh::OvhProvider;
 #[cfg(feature = "test_provider")]
 use providers::{in_memory::InMemoryProvider, pebble::PebbleProvider};
 
-pub use hickory_client::proto::dnssec;
+pub use hickory_proto::dnssec;
 use providers::{
     bunny::BunnyProvider, cloudflare::CloudflareProvider, desec::DesecProvider,
     digitalocean::DigitalOceanProvider, dnsimple::DNSimpleProvider, porkbun::PorkBunProvider,

--- a/src/providers/cloudflare.rs
+++ b/src/providers/cloudflare.rs
@@ -319,11 +319,7 @@ impl From<DnsRecord> for DnsContent {
                     usage: u8::from(tlsa.cert_usage),
                     selector: u8::from(tlsa.selector),
                     matching_type: u8::from(tlsa.matching),
-                    certificate: tlsa
-                        .cert_data
-                        .iter()
-                        .map(|b| format!("{b:02x}"))
-                        .collect(),
+                    certificate: tlsa.cert_data.iter().map(|b| format!("{b:02x}")).collect(),
                 },
             },
             DnsRecord::CAA(caa) => {

--- a/src/providers/rfc2136.rs
+++ b/src/providers/rfc2136.rs
@@ -13,29 +13,25 @@ use crate::utils::txt_chunks;
 use crate::{
     CAARecord, DnsRecord, DnsRecordType, Error, IntoFqdn, TlsaCertUsage, TlsaMatching, TlsaSelector,
 };
-use hickory_client::ClientError;
-use hickory_client::client::{Client, ClientHandle};
-use hickory_client::proto::ProtoError;
-use hickory_client::proto::dnssec::rdata::KEY;
-use hickory_client::proto::dnssec::rdata::tsig::TsigAlgorithm;
-use hickory_client::proto::dnssec::tsig::TSigner;
-use hickory_client::proto::dnssec::{Algorithm, DnsSecError, SigSigner, SigningKey};
-use hickory_client::proto::op::MessageFinalizer;
-use hickory_client::proto::op::ResponseCode;
-use hickory_client::proto::rr::rdata::caa::KeyValue;
-use hickory_client::proto::rr::rdata::tlsa::{CertUsage, Matching, Selector};
-use hickory_client::proto::rr::rdata::{A, AAAA, CAA, CNAME, MX, NS, SRV, TLSA, TXT};
-use hickory_client::proto::rr::{Name, RData, Record, RecordType};
-use hickory_client::proto::runtime::TokioRuntimeProvider;
-use hickory_client::proto::tcp::TcpClientStream;
-use hickory_client::proto::udp::UdpClientStream;
+use hickory_net::NetError;
+use hickory_net::client::{Client, ClientHandle};
+use hickory_net::runtime::TokioRuntimeProvider;
+use hickory_net::tcp::TcpClientStream;
+use hickory_net::udp::UdpClientStream;
+use hickory_proto::ProtoError;
+use hickory_proto::dnssec::DnsSecError;
+use hickory_proto::op::ResponseCode;
+use hickory_proto::rr::rdata::caa::KeyValue;
+use hickory_proto::rr::rdata::tlsa::{CertUsage, Matching, Selector};
+use hickory_proto::rr::rdata::tsig::TsigAlgorithm;
+use hickory_proto::rr::rdata::{A, AAAA, CAA, CNAME, MX, NS, SRV, TLSA, TXT};
+use hickory_proto::rr::{Name, RData, Record, RecordType, TSigner};
 use std::net::{AddrParseError, SocketAddr};
-use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Rfc2136Provider {
     addr: DnsAddress,
-    signer: Arc<dyn MessageFinalizer>,
+    signer: Option<TSigner>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -55,7 +51,7 @@ impl Rfc2136Provider {
             addr: addr
                 .try_into()
                 .map_err(|_| Error::Parse("Invalid address".to_string()))?,
-            signer: Arc::new(TSigner::new(
+            signer: Some(TSigner::new(
                 key.into(),
                 algorithm,
                 Name::from_ascii(key_name.as_ref())?,
@@ -64,47 +60,23 @@ impl Rfc2136Provider {
         })
     }
 
-    /// SIG(0) support is slated for removal in v0.3.0.
-    pub(crate) fn new_sig0(
-        addr: impl TryInto<DnsAddress>,
-        signer_name: impl AsRef<str>,
-        key: Box<dyn SigningKey>,
-        public_key: impl Into<Vec<u8>>,
-        algorithm: Algorithm,
-    ) -> crate::Result<Self> {
-        let sig0key = KEY::new(
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            algorithm,
-            public_key.into(),
-        );
-
-        let signer = SigSigner::sig0(sig0key, key, Name::from_str_relaxed(signer_name.as_ref())?);
-
-        Ok(Rfc2136Provider {
-            addr: addr
-                .try_into()
-                .map_err(|_| Error::Parse("Invalid address".to_string()))?,
-            signer: Arc::new(signer),
-        })
-    }
-
-    async fn connect(&self) -> crate::Result<Client> {
+    async fn connect(&self) -> crate::Result<Client<TokioRuntimeProvider>> {
         match &self.addr {
             DnsAddress::Udp(addr) => {
-                let stream = UdpClientStream::builder(*addr, TokioRuntimeProvider::new())
-                    .with_signer(Some(self.signer.clone()))
-                    .build();
-                let (client, bg) = Client::connect(stream).await?;
+                let mut builder = UdpClientStream::builder(*addr, TokioRuntimeProvider::new());
+                if let Some(signer) = &self.signer {
+                    builder = builder.with_signer(Some(signer.clone()));
+                }
+                let stream = builder.build();
+                let (client, bg) = Client::from_sender(stream);
                 tokio::spawn(bg);
                 Ok(client)
             }
             DnsAddress::Tcp(addr) => {
-                let (stream, sender) =
+                let (stream_future, sender) =
                     TcpClientStream::new(*addr, None, None, TokioRuntimeProvider::new());
-                let (client, bg) = Client::new(stream, sender, Some(self.signer.clone())).await?;
+                let stream = stream_future.await?;
+                let (client, bg) = Client::new(stream, sender);
                 tokio::spawn(bg);
                 Ok(client)
             }
@@ -129,10 +101,10 @@ impl Rfc2136Provider {
         let result = client
             .create(record, Name::from_str_relaxed(origin.into_fqdn().as_ref())?)
             .await?;
-        if result.response_code() == ResponseCode::NoError {
+        if result.response_code == ResponseCode::NoError {
             Ok(())
         } else {
-            Err(crate::Error::Response(result.response_code().to_string()))
+            Err(crate::Error::Response(result.response_code.to_string()))
         }
     }
 
@@ -158,10 +130,10 @@ impl Rfc2136Provider {
                 false,
             )
             .await?;
-        if result.response_code() == ResponseCode::NoError {
+        if result.response_code == ResponseCode::NoError {
             Ok(())
         } else {
-            Err(crate::Error::Response(result.response_code().to_string()))
+            Err(crate::Error::Response(result.response_code.to_string()))
         }
     }
 
@@ -181,10 +153,10 @@ impl Rfc2136Provider {
         let result = client
             .delete_rrset(record, Name::from_str_relaxed(origin.into_fqdn().as_ref())?)
             .await?;
-        if result.response_code() == ResponseCode::NoError {
+        if result.response_code == ResponseCode::NoError {
             Ok(())
         } else {
-            Err(crate::Error::Response(result.response_code().to_string()))
+            Err(crate::Error::Response(result.response_code.to_string()))
         }
     }
 }
@@ -386,18 +358,6 @@ impl From<crate::TsigAlgorithm> for TsigAlgorithm {
     }
 }
 
-impl From<crate::Algorithm> for Algorithm {
-    fn from(alg: crate::Algorithm) -> Self {
-        match alg {
-            crate::Algorithm::RSASHA256 => Algorithm::RSASHA256,
-            crate::Algorithm::RSASHA512 => Algorithm::RSASHA512,
-            crate::Algorithm::ECDSAP256SHA256 => Algorithm::ECDSAP256SHA256,
-            crate::Algorithm::ECDSAP384SHA384 => Algorithm::ECDSAP384SHA384,
-            crate::Algorithm::ED25519 => Algorithm::ED25519,
-        }
-    }
-}
-
 impl From<ProtoError> for Error {
     fn from(e: ProtoError) -> Self {
         Error::Protocol(e.to_string())
@@ -410,8 +370,8 @@ impl From<AddrParseError> for Error {
     }
 }
 
-impl From<ClientError> for Error {
-    fn from(e: ClientError) -> Self {
+impl From<NetError> for Error {
+    fn from(e: NetError) -> Self {
         Error::Client(e.to_string())
     }
 }

--- a/src/providers/route53.rs
+++ b/src/providers/route53.rs
@@ -279,7 +279,8 @@ impl Route53Provider {
             change_batch,
         };
 
-        let xml_body = to_string(&request).map_err(|e| format!("XML serialization error: {}", e))?;
+        let xml_body =
+            to_string(&request).map_err(|e| format!("XML serialization error: {}", e))?;
         let payload = format!("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n{}", xml_body);
 
         self.send_signed_request("POST", &url, Some(payload))
@@ -318,7 +319,10 @@ impl Route53Provider {
         let parsed_url = url.parse::<reqwest::Url>()?;
         let canonical_uri = parsed_url.path();
         let canonical_querystring = parsed_url.query().unwrap_or("");
-        let canonical_headers = format!("content-type:application/xml\nhost:{}\nx-amz-date:{}\n", ROUTE53_HOST, amz_date);
+        let canonical_headers = format!(
+            "content-type:application/xml\nhost:{}\nx-amz-date:{}\n",
+            ROUTE53_HOST, amz_date
+        );
         let signed_headers = "content-type;host;x-amz-date";
 
         let canonical_request = format!(

--- a/src/tests/desec_tests.rs
+++ b/src/tests/desec_tests.rs
@@ -149,7 +149,6 @@ mod tests {
             "records": ["2001:db8::1"],
         });
 
-
         let mock = server
             .mock("PUT", "/domains/example.com/rrsets/test/AAAA/")
             .with_status(200)
@@ -470,47 +469,284 @@ mod tests {
         // --- Create & update all record types ---
 
         // A record
-        assert!(provider.create(domain, DnsRecord::A("1.1.1.1".parse().unwrap()), 3600, origin).await.is_ok());
-        assert!(provider.update(domain, DnsRecord::A("2.2.2.2".parse().unwrap()), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    domain,
+                    DnsRecord::A("1.1.1.1".parse().unwrap()),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    domain,
+                    DnsRecord::A("2.2.2.2".parse().unwrap()),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // AAAA record
-        assert!(provider.create(domain, DnsRecord::AAAA("2001:db8::1".parse().unwrap()), 3600, origin).await.is_ok());
-        assert!(provider.update(domain, DnsRecord::AAAA("2001:db8::2".parse().unwrap()), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    domain,
+                    DnsRecord::AAAA("2001:db8::1".parse().unwrap()),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    domain,
+                    DnsRecord::AAAA("2001:db8::2".parse().unwrap()),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // TXT record
-        assert!(provider.create(domain, DnsRecord::TXT("v=spf1 -all".to_string()), 3600, origin).await.is_ok());
-        assert!(provider.update(domain, DnsRecord::TXT("v=spf1 ~all".to_string()), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    domain,
+                    DnsRecord::TXT("v=spf1 -all".to_string()),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    domain,
+                    DnsRecord::TXT("v=spf1 ~all".to_string()),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // MX record
-        assert!(provider.create(domain, DnsRecord::MX(MXRecord { exchange: format!("mail.{origin}"), priority: 10 }), 3600, origin).await.is_ok());
-        assert!(provider.update(domain, DnsRecord::MX(MXRecord { exchange: format!("mail2.{origin}"), priority: 20 }), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    domain,
+                    DnsRecord::MX(MXRecord {
+                        exchange: format!("mail.{origin}"),
+                        priority: 10
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    domain,
+                    DnsRecord::MX(MXRecord {
+                        exchange: format!("mail2.{origin}"),
+                        priority: 20
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // CNAME record (dedicated subdomain — cannot coexist with other record types)
-        assert!(provider.create(&cname_sub, DnsRecord::CNAME(format!("target.{origin}")), 3600, origin).await.is_ok());
-        assert!(provider.update(&cname_sub, DnsRecord::CNAME(format!("target2.{origin}")), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    &cname_sub,
+                    DnsRecord::CNAME(format!("target.{origin}")),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    &cname_sub,
+                    DnsRecord::CNAME(format!("target2.{origin}")),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // SRV record
-        assert!(provider.create(&srv_sub, DnsRecord::SRV(SRVRecord { priority: 10, weight: 20, port: 5060, target: format!("sip.{origin}") }), 3600, origin).await.is_ok());
-        assert!(provider.update(&srv_sub, DnsRecord::SRV(SRVRecord { priority: 20, weight: 10, port: 5060, target: format!("sip2.{origin}") }), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    &srv_sub,
+                    DnsRecord::SRV(SRVRecord {
+                        priority: 10,
+                        weight: 20,
+                        port: 5060,
+                        target: format!("sip.{origin}")
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    &srv_sub,
+                    DnsRecord::SRV(SRVRecord {
+                        priority: 20,
+                        weight: 10,
+                        port: 5060,
+                        target: format!("sip2.{origin}")
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // TLSA record
-        assert!(provider.create(&tlsa_sub, DnsRecord::TLSA(TLSARecord { cert_usage: TlsaCertUsage::DaneEe, selector: TlsaSelector::Spki, matching: TlsaMatching::Sha256, cert_data: vec![0xe3, 0xb0, 0xc4, 0x42] }), 3600, origin).await.is_ok());
-        assert!(provider.update(&tlsa_sub, DnsRecord::TLSA(TLSARecord { cert_usage: TlsaCertUsage::DaneEe, selector: TlsaSelector::Spki, matching: TlsaMatching::Sha256, cert_data: vec![0xab, 0xcd, 0xef, 0x01] }), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    &tlsa_sub,
+                    DnsRecord::TLSA(TLSARecord {
+                        cert_usage: TlsaCertUsage::DaneEe,
+                        selector: TlsaSelector::Spki,
+                        matching: TlsaMatching::Sha256,
+                        cert_data: vec![0xe3, 0xb0, 0xc4, 0x42]
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    &tlsa_sub,
+                    DnsRecord::TLSA(TLSARecord {
+                        cert_usage: TlsaCertUsage::DaneEe,
+                        selector: TlsaSelector::Spki,
+                        matching: TlsaMatching::Sha256,
+                        cert_data: vec![0xab, 0xcd, 0xef, 0x01]
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // CAA record
-        assert!(provider.create(domain, DnsRecord::CAA(CAARecord::Issue { issuer_critical: false, name: Some("letsencrypt.org".to_string()), options: vec![] }), 3600, origin).await.is_ok());
-        assert!(provider.update(domain, DnsRecord::CAA(CAARecord::Issue { issuer_critical: false, name: Some("sectigo.com".to_string()), options: vec![] }), 3600, origin).await.is_ok());
+        assert!(
+            provider
+                .create(
+                    domain,
+                    DnsRecord::CAA(CAARecord::Issue {
+                        issuer_critical: false,
+                        name: Some("letsencrypt.org".to_string()),
+                        options: vec![]
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
+        assert!(
+            provider
+                .update(
+                    domain,
+                    DnsRecord::CAA(CAARecord::Issue {
+                        issuer_critical: false,
+                        name: Some("sectigo.com".to_string()),
+                        options: vec![]
+                    }),
+                    3600,
+                    origin
+                )
+                .await
+                .is_ok()
+        );
 
         // Set DESEC_NO_CLEANUP=1 to skip deletion (e.g. to inspect records in the web UI).
-        if std::env::var("DESEC_NO_CLEANUP").unwrap_or_default().is_empty() {
-            assert!(provider.delete(domain, origin, DnsRecordType::A).await.is_ok());
-            assert!(provider.delete(domain, origin, DnsRecordType::AAAA).await.is_ok());
-            assert!(provider.delete(domain, origin, DnsRecordType::TXT).await.is_ok());
-            assert!(provider.delete(domain, origin, DnsRecordType::MX).await.is_ok());
-            assert!(provider.delete(&cname_sub, origin, DnsRecordType::CNAME).await.is_ok());
-            assert!(provider.delete(&srv_sub, origin, DnsRecordType::SRV).await.is_ok());
-            assert!(provider.delete(&tlsa_sub, origin, DnsRecordType::TLSA).await.is_ok());
-            assert!(provider.delete(domain, origin, DnsRecordType::CAA).await.is_ok());
+        if std::env::var("DESEC_NO_CLEANUP")
+            .unwrap_or_default()
+            .is_empty()
+        {
+            assert!(
+                provider
+                    .delete(domain, origin, DnsRecordType::A)
+                    .await
+                    .is_ok()
+            );
+            assert!(
+                provider
+                    .delete(domain, origin, DnsRecordType::AAAA)
+                    .await
+                    .is_ok()
+            );
+            assert!(
+                provider
+                    .delete(domain, origin, DnsRecordType::TXT)
+                    .await
+                    .is_ok()
+            );
+            assert!(
+                provider
+                    .delete(domain, origin, DnsRecordType::MX)
+                    .await
+                    .is_ok()
+            );
+            assert!(
+                provider
+                    .delete(&cname_sub, origin, DnsRecordType::CNAME)
+                    .await
+                    .is_ok()
+            );
+            assert!(
+                provider
+                    .delete(&srv_sub, origin, DnsRecordType::SRV)
+                    .await
+                    .is_ok()
+            );
+            assert!(
+                provider
+                    .delete(&tlsa_sub, origin, DnsRecordType::TLSA)
+                    .await
+                    .is_ok()
+            );
+            assert!(
+                provider
+                    .delete(domain, origin, DnsRecordType::CAA)
+                    .await
+                    .is_ok()
+            );
         }
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,12 +10,6 @@
  */
 
 #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
-use crate::Algorithm;
-
-#[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
-use hickory_client::proto::dnssec::SigningKey;
-
-#[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
 use crate::providers::ovh::{OvhEndpoint, OvhProvider};
 
 #[cfg(feature = "test_provider")]
@@ -55,34 +49,6 @@ impl DnsUpdater {
             addr,
             key_name,
             key,
-            algorithm.into(),
-        )?))
-    }
-
-    /// Create a new DNS updater using the RFC 2136 protocol and SIG(0) authentication.
-    ///
-    /// **Deprecated:** SIG(0) support will be removed in v0.3.0. Upstream
-    /// `hickory-client` has dropped SIG(0) message authentication in v0.26
-    /// (see hickory-dns/hickory-dns#3437) due to negligible real-world use, and
-    /// every production RFC 2136 endpoint and ACME client uses TSIG. Migrate to
-    /// [`DnsUpdater::new_rfc2136_tsig`].
-    #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
-    #[deprecated(
-        since = "0.2.1",
-        note = "SIG(0) will be removed in v0.3.0, upstream hickory-client v0.26 drops SIG(0) message authentication; use `new_rfc2136_tsig` instead"
-    )]
-    pub fn new_rfc2136_sig0(
-        addr: impl TryInto<DnsAddress>,
-        signer_name: impl AsRef<str>,
-        key: Box<dyn SigningKey>,
-        public_key: impl Into<Vec<u8>>,
-        algorithm: Algorithm,
-    ) -> crate::Result<Self> {
-        Ok(DnsUpdater::Rfc2136(Rfc2136Provider::new_sig0(
-            addr,
-            signer_name,
-            key,
-            public_key,
             algorithm.into(),
         )?))
     }


### PR DESCRIPTION
Hello,

As discussed in #38, hickory-client has been deprecated, and there are two outstanding CVE/RUSTSEC vulnerabilities that are patched in v0.26.x. They are:

* [RUSTSEC-2026-0120](https://rustsec.org/advisories/RUSTSEC-2026-0120.html)
* [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119.html)

Hickory-client was deprecated with this release; `dns-update` now uses more of the primitives `hickory-proto` and `hickory-net`. 

I have also bumped tokio and quickxml crates.
