### PR TITLE
Fix IONOS provider missing User-Agent and dropped SRV prio

### DIFF
--- a/src/providers/ionos.rs
+++ b/src/providers/ionos.rs
@@ -81,6 +81,10 @@ impl IonosProvider {
         let client = HttpClientBuilder::default()
             .with_header("X-Api-Key", api_key.as_ref())
             .with_header("Accept", "application/json")
+            .with_header(
+                "User-Agent",
+                concat!("dns-update/", env!("CARGO_PKG_VERSION")),
+            )
             .with_timeout(timeout)
             .build();
         Self {

--- a/src/providers/ionos.rs
+++ b/src/providers/ionos.rs
@@ -49,7 +49,7 @@ struct Record {
     ttl: u32,
     #[serde(rename = "type")]
     record_type: String,
-    #[serde(default, skip_serializing_if = "is_zero_u16", rename = "prio")]
+    #[serde(default, rename = "prio")]
     priority: u16,
     #[serde(default, skip_serializing_if = "is_false")]
     disabled: bool,
@@ -66,10 +66,6 @@ impl RecordContent {
     fn rdata_matches(&self, other: &Self) -> bool {
         self.content == other.content && self.priority == other.priority
     }
-}
-
-fn is_zero_u16(v: &u16) -> bool {
-    *v == 0
 }
 
 fn is_false(v: &bool) -> bool {


### PR DESCRIPTION
Hi,
     
  This PR fixes two issues preventing IONOS DNS from working.
     
 1.  **User-Agent header**
  IONOS needs a `User-Agent` header, otherwise you get HTTP 503. Added one.
  
  2. **Missing `prio` field**
 IONOS requires the `prio` field on SRV records, but on priority 0 the field got dropped. Ensured it's always sent.
  
  I confirmed these patches against my own stack with IONOS.
