### PR TITLE
Namecheap TXT split-record fix

### DIFF
--- a/src/providers/namecheap.rs
+++ b/src/providers/namecheap.rs
@@ -12,7 +12,7 @@
 use crate::{
     CAARecord, DnsRecord, DnsRecordType, Error, IntoFqdn, KeyValue, MXRecord,
     http::{HttpClient, HttpClientBuilder},
-    utils::{strip_origin_from_name, txt_chunks},
+    utils::strip_origin_from_name,
 };
 use quick_xml::de::from_str;
 use serde::Deserialize;
@@ -492,17 +492,15 @@ fn build_hosts_for_record(
             caa_tag: None,
         }),
         DnsRecord::TXT(content) => {
-            for chunk in txt_chunks(content) {
-                hosts.push(Host {
-                    name: subdomain.to_string(),
-                    record_type: type_str.clone(),
-                    address: chunk,
-                    mx_pref: mx_pref.clone(),
-                    ttl: ttl_str.clone(),
-                    caa_flag: None,
-                    caa_tag: None,
-                });
-            }
+            hosts.push(Host {
+                name: subdomain.to_string(),
+                record_type: type_str,
+                address: content,
+                mx_pref,
+                ttl: ttl_str,
+                caa_flag: None,
+                caa_tag: None,
+            });
         }
         DnsRecord::SRV(_) => {
             return Err(Error::Unsupported(

--- a/src/tests/namecheap_tests.rs
+++ b/src/tests/namecheap_tests.rs
@@ -483,7 +483,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_txt_long_value_is_chunked() {
+    async fn test_set_rrset_long_txt_emitted_as_single_entry() {
         let mut server = mockito::Server::new_async().await;
         let body = get_hosts_xml("");
         let get = server
@@ -493,18 +493,25 @@ mod tests {
             .with_body(body)
             .create();
 
-        let long = "a".repeat(260);
-        let chunk1 = "a".repeat(255);
-        let chunk2 = "a".repeat(5);
+        let long = format!(
+            "v=DKIM1; k=rsa; p={}{}",
+            "A".repeat(200),
+            "B".repeat(220),
+        );
 
+        let long_for_match = long.clone();
         let set = server
             .mock("POST", "/xml.response")
             .match_body(Matcher::AllOf(vec![
+                Matcher::UrlEncoded("Command".into(), "namecheap.domains.dns.setHosts".into()),
+                Matcher::UrlEncoded("HostName1".into(), "dkim".into()),
                 Matcher::UrlEncoded("RecordType1".into(), "TXT".into()),
-                Matcher::UrlEncoded("Address1".into(), chunk1),
-                Matcher::UrlEncoded("RecordType2".into(), "TXT".into()),
-                Matcher::UrlEncoded("Address2".into(), chunk2),
+                Matcher::UrlEncoded("Address1".into(), long_for_match),
             ]))
+            .match_request(|req| {
+                let body = req.utf8_lossy_body().unwrap_or_default();
+                !body.contains("HostName2")
+            })
             .with_status(200)
             .with_body(SET_HOSTS_OK)
             .create();
@@ -512,7 +519,7 @@ mod tests {
         let provider = provider(server.url());
         let result = provider
             .set_rrset(
-                "long.example.com",
+                "dkim.example.com",
                 DnsRecordType::TXT,
                 300,
                 vec![DnsRecord::TXT(long)],


### PR DESCRIPTION
- Corrected the behavior of the set_hosts command in the namecheap provider when adding a TXT record whose length exceeds 256 bytes. 
  - It was previously chunking the TXT record into multiple smaller instances, however the Namecheap API accepts it as one large instance.
  - If a split record is sent, it will actually create multiple TXT records in the domainn with the same selector/host.
  - In particular when this library is used in stalwart when dealing with DKIM entries for RSA, the records typically far exceed 256 bytes, and I needed to manually "recombine" the DKIM TXT record after the fact.