### PR TITLE
feat(route53): support custom endpoint for non-commercial AWS partitions

### DIFF
--- a/src/providers/route53.rs
+++ b/src/providers/route53.rs
@@ -35,9 +35,32 @@ pub struct Route53Config {
     pub access_key_id: String,
     pub secret_access_key: String,
     pub session_token: Option<String>,
+    /// Signing region. Defaults to `us-east-1` (AWS Commercial) when `None`.
+    ///
+    /// Set to `cn-northwest-1` for AWS China and to the appropriate region
+    /// code for other partitions.
     pub region: Option<String>,
     pub hosted_zone_id: Option<String>,
     pub private_zone_only: Option<bool>,
+    /// Custom Route 53 API endpoint URL. When `None`, defaults to the AWS
+    /// Commercial global endpoint (`https://route53.amazonaws.com`).
+    ///
+    /// Set this when targeting a non-commercial AWS partition:
+    ///
+    /// | Partition | Endpoint | Signing region |
+    /// |-----------|----------|----------------|
+    /// | Commercial (`aws`) | `https://route53.amazonaws.com` (default) | `us-east-1` |
+    /// | GovCloud (`aws-us-gov`) | `https://route53.us-gov.amazonaws.com` | `us-gov-west-1` |
+    /// | China (`aws-cn`) | `https://route53.amazonaws.com.cn` | `cn-northwest-1` |
+    /// | EU Sovereign Cloud (`aws-eusc`) | `https://route53.amazonaws.eu` | `eusc-de-east-1` |
+    ///
+    /// The isolated partitions (`aws-iso`, `aws-iso-b`, `aws-iso-e`,
+    /// `aws-iso-f`) are air-gapped environments; endpoints are not publicly
+    /// documented. Consult your environment's documentation.
+    ///
+    /// For the latest official endpoint list see:
+    /// <https://docs.aws.amazon.com/general/latest/gr/r53.html>
+    pub endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -55,11 +78,16 @@ impl Route53Provider {
             .clone()
             .unwrap_or_else(|| "us-east-1".to_string());
 
+        let endpoint = match config.endpoint.clone() {
+            Some(ep) => Cow::Owned(ep),
+            None => Cow::Borrowed(ROUTE53_DEFAULT_ENDPOINT),
+        };
+
         Self {
             client: Client::new(),
             config,
             region,
-            endpoint: Cow::Borrowed(ROUTE53_DEFAULT_ENDPOINT),
+            endpoint,
         }
     }
 

--- a/src/providers/route53.rs
+++ b/src/providers/route53.rs
@@ -35,31 +35,9 @@ pub struct Route53Config {
     pub access_key_id: String,
     pub secret_access_key: String,
     pub session_token: Option<String>,
-    /// Signing region. Defaults to `us-east-1` (AWS Commercial) when `None`.
-    ///
-    /// Set to `cn-northwest-1` for AWS China and to the appropriate region
-    /// code for other partitions.
     pub region: Option<String>,
     pub hosted_zone_id: Option<String>,
     pub private_zone_only: Option<bool>,
-    /// Custom Route 53 API endpoint URL. When `None`, defaults to the AWS
-    /// Commercial global endpoint (`https://route53.amazonaws.com`).
-    ///
-    /// Set this when targeting a non-commercial AWS partition:
-    ///
-    /// | Partition | Endpoint | Signing region |
-    /// |-----------|----------|----------------|
-    /// | Commercial (`aws`) | `https://route53.amazonaws.com` (default) | `us-east-1` |
-    /// | GovCloud (`aws-us-gov`) | `https://route53.us-gov.amazonaws.com` | `us-gov-west-1` |
-    /// | China (`aws-cn`) | `https://route53.amazonaws.com.cn` | `cn-northwest-1` |
-    /// | EU Sovereign Cloud (`aws-eusc`) | `https://route53.amazonaws.eu` | `eusc-de-east-1` |
-    ///
-    /// The isolated partitions (`aws-iso`, `aws-iso-b`, `aws-iso-e`,
-    /// `aws-iso-f`) are air-gapped environments; endpoints are not publicly
-    /// documented. Consult your environment's documentation.
-    ///
-    /// For the latest official endpoint list see:
-    /// <https://docs.aws.amazon.com/general/latest/gr/r53.html>
     pub endpoint: Option<String>,
 }
 

--- a/src/tests/route53_tests.rs
+++ b/src/tests/route53_tests.rs
@@ -26,6 +26,7 @@ fn setup_provider(endpoint: String) -> Route53Provider {
         region: Some("us-east-1".to_string()),
         hosted_zone_id: Some(ZONE_ID.to_string()),
         private_zone_only: Some(false),
+        endpoint: None,
     })
     .with_endpoint(endpoint)
 }
@@ -38,6 +39,7 @@ fn setup_provider_zone_lookup(endpoint: String) -> Route53Provider {
         region: Some("us-east-1".to_string()),
         hosted_zone_id: None,
         private_zone_only: Some(false),
+        endpoint: None,
     })
     .with_endpoint(endpoint)
 }
@@ -124,6 +126,7 @@ async fn test_route53_provider_creation() {
         region: Some("us-east-1".to_string()),
         hosted_zone_id: Some("test_zone_id".to_string()),
         private_zone_only: Some(false),
+        endpoint: None,
     });
 }
 
@@ -136,6 +139,7 @@ async fn test_route53_updater_creation() {
         region: Some("us-west-2".to_string()),
         hosted_zone_id: None,
         private_zone_only: Some(true),
+        endpoint: None,
     })
     .unwrap();
     match updater {
@@ -153,6 +157,7 @@ async fn test_route53_config_defaults() {
         region: None,
         hosted_zone_id: None,
         private_zone_only: None,
+        endpoint: None,
     });
 }
 
@@ -165,6 +170,7 @@ async fn test_route53_config_with_session_token() {
         region: Some("eu-west-1".to_string()),
         hosted_zone_id: Some("Z1234567890".to_string()),
         private_zone_only: Some(true),
+        endpoint: None,
     });
 }
 
@@ -177,12 +183,48 @@ async fn test_route53_config_minimal() {
         region: None,
         hosted_zone_id: None,
         private_zone_only: None,
+        endpoint: None,
     })
     .unwrap();
     match updater {
         DnsUpdater::Route53(_) => {}
         _ => panic!("Expected Route53 provider"),
     }
+}
+
+#[tokio::test]
+async fn test_route53_custom_endpoint_from_config() {
+    let mut server = mockito::Server::new_async().await;
+    let change = mock_change(
+        &mut server,
+        vec![
+            r"<Action>UPSERT</Action>".to_string(),
+            r"<Value>1\.2\.3\.4</Value>".to_string(),
+        ],
+    );
+
+    let provider = Route53Provider::new(Route53Config {
+        access_key_id: "AKIA_TEST".to_string(),
+        secret_access_key: "test_secret".to_string(),
+        session_token: None,
+        region: Some("eu-central-1".to_string()),
+        hosted_zone_id: Some(ZONE_ID.to_string()),
+        private_zone_only: Some(false),
+        endpoint: Some(server.url()),
+    });
+
+    let result = provider
+        .set_rrset(
+            "host.example.com",
+            DnsRecordType::A,
+            300,
+            vec![DnsRecord::A("1.2.3.4".parse().unwrap())],
+            "example.com",
+        )
+        .await;
+
+    assert!(result.is_ok(), "set_rrset returned: {result:?}");
+    change.assert();
 }
 
 #[tokio::test]
@@ -843,6 +885,7 @@ async fn test_session_token_is_signed() {
         region: Some("us-east-1".to_string()),
         hosted_zone_id: Some(ZONE_ID.to_string()),
         private_zone_only: Some(false),
+        endpoint: None,
     })
     .with_endpoint(endpoint);
 
@@ -991,6 +1034,7 @@ async fn integration_test() {
         region: Some("us-east-1".to_string()),
         hosted_zone_id,
         private_zone_only: Some(false),
+        endpoint: None,
     });
 
     provider


### PR DESCRIPTION
Closes #74 

Adds an optional endpoint field to Route53Config. When set, the provider sends API requests to the specified URL instead of the default https://route53.amazonaws.com. This enables usage with AWS GovCloud, China, European Sovereign Cloud, and other partitions.

The default behavior is unchanged: when endpoint is None, the provider uses the commercial global endpoint.

## Changes:
  - src/providers/route53.rs: add endpoint to Route53Config, wire it into Route53Provider::new()
  - src/tests/route53_tests.rs: add test_route53_custom_endpoint_from_config, update existing test configs

## Usage:

```rust
  let updater = DnsUpdater::new_route53(Route53Config {
      access_key_id: "...".into(),
      secret_access_key: "...".into(),
      session_token: None,
      region: Some("eusc-de-east-1".into()),
      hosted_zone_id: None,
      private_zone_only: None,
      endpoint: Some("https://route53.amazonaws.eu".into()),
  })?;
```
