### PR TITLE
Add US OVH Endpoint

### DIFF
--- a/src/providers/ovh.rs
+++ b/src/providers/ovh.rs
@@ -64,6 +64,7 @@ struct OvhRecordBody {
 #[derive(Debug)]
 pub enum OvhEndpoint {
     OvhEu,
+    OvhUs,
     OvhCa,
     KimsufiEu,
     KimsufiCa,
@@ -75,6 +76,7 @@ impl OvhEndpoint {
     fn api_url(&self) -> &'static str {
         match self {
             OvhEndpoint::OvhEu => "https://eu.api.ovh.com/1.0",
+            OvhEndpoint::OvhUs => "https://api.us.ovhcloud.com/1.0",
             OvhEndpoint::OvhCa => "https://ca.api.ovh.com/1.0",
             OvhEndpoint::KimsufiEu => "https://eu.api.kimsufi.com/1.0",
             OvhEndpoint::KimsufiCa => "https://ca.api.kimsufi.com/1.0",
@@ -90,6 +92,7 @@ impl std::str::FromStr for OvhEndpoint {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "ovh-eu" => Ok(OvhEndpoint::OvhEu),
+            "ovh-us" => Ok(OvhEndpoint::OvhUs),
             "ovh-ca" => Ok(OvhEndpoint::OvhCa),
             "kimsufi-eu" => Ok(OvhEndpoint::KimsufiEu),
             "kimsufi-ca" => Ok(OvhEndpoint::KimsufiCa),

--- a/src/tests/ovh_tests.rs
+++ b/src/tests/ovh_tests.rs
@@ -37,6 +37,10 @@ mod tests {
             OvhEndpoint::OvhEu
         ));
         assert!(matches!(
+            "ovh-us".parse::<OvhEndpoint>().unwrap(),
+            OvhEndpoint::OvhUs
+        ));
+        assert!(matches!(
             "ovh-ca".parse::<OvhEndpoint>().unwrap(),
             OvhEndpoint::OvhCa
         ));


### PR DESCRIPTION
Support for OVH was requested in #14 and added with #16. However, the US endpoint was not included in this PR. In this PR I have simply added the US endpoint and enum. According to OVH's documentation, this API is the same for all regions.

The only thing of note is that the US endpoint goes "api.us" instead of "us.api". This is not a mistake, it supposed to be in that order.