### PR TITLE
Update `quick-xml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde_urlencoded = { version = "0.7.1", default-features = false }
 ring = { version = "0.17", optional = true }
 aws-lc-rs = { version = "1.17", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
-quick-xml = { version = "0.40", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 chrono = { version = "0.4" , default-features = false, features = ["std", "clock", "now"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Addresses [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) (I saw this in `cargo audit`).