### PR TITLE
Mythic Beasts: Ensure Request Content Type is Overwritten not Appended

### DIFF
--- a/src/providers/joker.rs
+++ b/src/providers/joker.rs
@@ -84,7 +84,7 @@ impl JokerProvider {
     pub(crate) fn new(auth: JokerAuth, timeout: Option<Duration>) -> crate::Result<Self> {
         auth.validate()?;
         let client = HttpClientBuilder::default()
-            .with_header("Content-Type", "application/x-www-form-urlencoded")
+            .set_header("Content-Type", "application/x-www-form-urlencoded")
             .with_header("Accept", "text/plain")
             .with_timeout(timeout)
             .build();

--- a/src/providers/mythicbeasts.rs
+++ b/src/providers/mythicbeasts.rs
@@ -166,7 +166,7 @@ impl MythicBeastsProvider {
             .client
             .post(self.auth_endpoint.clone())
             .with_header("Authorization", format!("Basic {credentials}"))
-            .with_header("Content-Type", "application/x-www-form-urlencoded")
+            .set_header("Content-Type", "application/x-www-form-urlencoded")
             .with_raw_body("grant_type=client_credentials".to_string())
             .send()
             .await?;

--- a/src/providers/tencentcloud.rs
+++ b/src/providers/tencentcloud.rs
@@ -426,7 +426,7 @@ impl TencentCloudProvider {
             .client
             .post(self.endpoint.clone())
             .with_header("Authorization", authorization)
-            .with_header("Content-Type", content_type)
+            .set_header("Content-Type", content_type)
             .with_header("Host", self.host.clone())
             .with_header("X-TC-Action", action)
             .with_header("X-TC-Timestamp", timestamp)

--- a/src/tests/joker_tests.rs
+++ b/src/tests/joker_tests.rs
@@ -569,10 +569,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn login_uses_form_content_type() {
+    async fn test_auth_uses_form_content_type() {
         let mut server = mockito::Server::new_async().await;
 
-        let login = server
+        let auth = server
             .mock("POST", "/login")
             .match_header("content-type", "application/x-www-form-urlencoded")
             .with_status(200)
@@ -591,7 +591,7 @@ mod tests {
             .list_rrset("www.example.com", DnsRecordType::A, "example.com")
             .await;
         assert!(res.is_ok(), "{res:?}");
-        login.assert();
+        auth.assert();
         get.assert();
     }
 }

--- a/src/tests/joker_tests.rs
+++ b/src/tests/joker_tests.rs
@@ -567,4 +567,31 @@ mod tests {
         fresh_get.assert();
         put.assert();
     }
+
+    #[tokio::test]
+    async fn login_uses_form_content_type() {
+        let mut server = mockito::Server::new_async().await;
+
+        let login = server
+            .mock("POST", "/login")
+            .match_header("content-type", "application/x-www-form-urlencoded")
+            .with_status(200)
+            .with_body("Status-Code: 0\nStatus-Text: OK\nAuth-Sid: sid\n\n")
+            .create();
+
+        let get = get_zone_mock(
+            &mut server,
+            "sid",
+            "example.com",
+            "example.com. 300 A 1.1.1.1",
+        );
+
+        let p = provider(server.url());
+        let res = p
+            .list_rrset("www.example.com", DnsRecordType::A, "example.com")
+            .await;
+        assert!(res.is_ok(), "{res:?}");
+        login.assert();
+        get.assert();
+    }
 }

--- a/src/tests/mythicbeasts_tests.rs
+++ b/src/tests/mythicbeasts_tests.rs
@@ -627,4 +627,30 @@ mod tests {
         token.assert();
         list.assert();
     }
+
+    #[tokio::test]
+    async fn test_auth_uses_form_content_type() {
+        let mut server = mockito::Server::new_async().await;
+
+        let auth = server
+            .mock("POST", "/auth/login")
+            .match_header("content-type", "application/x-www-form-urlencoded")
+            .with_status(200)
+            .with_body(r#"{"access_token":"tok","expires_in":3600,"token_type":"bearer"}"#)
+            .create();
+
+        let get = server
+            .mock("GET", "/dns/v2/zones/example.com/records/www/A")
+            .with_status(200)
+            .with_body(r#"{"records":[]}"#)
+            .create();
+
+        let p = provider(server.url());
+        let result = p
+            .list_rrset("www.example.com", DnsRecordType::A, "example.com")
+            .await;
+        assert!(result.is_ok(), "list_rrset returned {result:?}");
+        auth.assert();
+        get.assert();
+    }
 }

--- a/src/tests/tencentcloud_tests.rs
+++ b/src/tests/tencentcloud_tests.rs
@@ -555,7 +555,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn api_uses_charset_content_type() {
+    async fn test_uses_charset_content_type() {
         let mut server = mockito::Server::new_async().await;
 
         let domain_list = mock_domain_list(&mut server);

--- a/src/tests/tencentcloud_tests.rs
+++ b/src/tests/tencentcloud_tests.rs
@@ -553,4 +553,27 @@ mod tests {
             .await;
         assert!(delete_result.is_ok(), "delete failed: {delete_result:?}");
     }
+
+    #[tokio::test]
+    async fn api_uses_charset_content_type() {
+        let mut server = mockito::Server::new_async().await;
+
+        let domain_list = mock_domain_list(&mut server);
+
+        let list_records = server
+            .mock("POST", "/")
+            .match_header("X-TC-Action", "DescribeRecordList")
+            .match_header("content-type", "application/json; charset=utf-8")
+            .with_status(200)
+            .with_body(r#"{"Response":{"RecordList":[],"TotalCount":0,"RequestId":"x"}}"#)
+            .create();
+
+        let p = setup_provider(&server.url());
+        let result = p
+            .list_rrset("www.example.com", DnsRecordType::A, "example.com")
+            .await;
+        assert!(result.is_ok(), "list failed: {result:?}");
+        domain_list.assert();
+        list_records.assert();
+    }
 }


### PR DESCRIPTION
Should fix #70.

The issue is within the following lines:

https://github.com/stalwartlabs/dns-update/blob/fe5cf3af1310eff1ebb0754de598d63441270b04/src/providers/mythicbeasts.rs#L165-L172

https://github.com/stalwartlabs/dns-update/blob/fe5cf3af1310eff1ebb0754de598d63441270b04/src/http.rs#L48-L56

By using `with_header`, a second Content-Type header was added alongside the default `application/json`. The Mythic Beasts auth endpoint rejected this with `invalid_request`. With `set_header`, the default `application/json` is replaced, so only `application/x-www-form-urlencoded` is sent.

*Disclaimer*: This PR is LLM assisted. I used it for finding the error.